### PR TITLE
README.md: add build information

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Ultimately, your directory structure should look like this:
 
 ## Build
 
+- Install node v8.14.10
+- `cd alerting-kibana-plugin`
+- `yarn add --dev link:../../kibana/packages/kbn-plugin-helpers`
+- `yarn kbn bootstrap`
+- PATH="../../kibana/x-pack/node_modules/.bin:${PATH}"
+
 To build the plugin's distributable zip simply run `yarn build`.
 
 Example output: `./build/opendistro-alerting-0.7.0.0.zip`


### PR DESCRIPTION
*Issue #, if available:*
The only build information was to run `yarn build`. But there are some more commands required to successfully build.

*Description of changes:*
This change adds information to README.md how to build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
