### PR TITLE
Adds DELETED alert state to Dashboard filter

### DIFF
--- a/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
+++ b/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
@@ -15,6 +15,7 @@
 
 import React from 'react';
 import { EuiFieldSearch, EuiFlexGroup, EuiSelect, EuiFlexItem, EuiPagination } from '@elastic/eui';
+import { ALERT_STATE } from '../../../../utils/constants';
 
 const severityOptions = [
   { value: 'ALL', text: 'All severity levels' },
@@ -27,10 +28,11 @@ const severityOptions = [
 
 const stateOptions = [
   { value: 'ALL', text: 'All alerts' },
-  { value: 'ACTIVE', text: 'Active' },
-  { value: 'ACKNOWLEDGED', text: 'Acknowledged' },
-  { value: 'COMPLETED', text: 'Completed' },
-  { value: 'ERROR', text: 'Error' },
+  { value: ALERT_STATE.ACTIVE, text: 'Active' },
+  { value: ALERT_STATE.ACKNOWLEDGED, text: 'Acknowledged' },
+  { value: ALERT_STATE.COMPLETED, text: 'Completed' },
+  { value: ALERT_STATE.ERROR, text: 'Error' },
+  { value: ALERT_STATE.DELETED, text: 'Deleted' },
 ];
 
 const DashboardControls = ({

--- a/public/pages/Dashboard/components/DashboardControls/__snapshots__/DashboardControls.test.js.snap
+++ b/public/pages/Dashboard/components/DashboardControls/__snapshots__/DashboardControls.test.js.snap
@@ -165,6 +165,11 @@ exports[`DashboardControls renders 1`] = `
           >
             Error
           </option>
+          <option
+            value="DELETED"
+          >
+            Deleted
+          </option>
         </select>
         <div
           class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"

--- a/public/utils/constants.js
+++ b/public/utils/constants.js
@@ -18,6 +18,7 @@ export const ALERT_STATE = Object.freeze({
   ACKNOWLEDGED: 'ACKNOWLEDGED',
   COMPLETED: 'COMPLETED',
   ERROR: 'ERROR',
+  DELETED: 'DELETED',
 });
 
 export const DEFAULT_EMPTY_DATA = '-';


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/issues/30

*Description of changes:*
Adds DELETED alert state to Alert Dashboard filter and updates snapshot.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
