### PR TITLE
No documents for aggregations count as false

### DIFF
--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.test.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.test.js
@@ -66,7 +66,7 @@ describe('formikToCondition', () => {
     expect(
       formikToCondition(formikValues, { search: { searchType: 'graph', aggregationType: 'max' } })
     ).toEqual({
-      script: { lang: 'painless', source: `ctx.results[0].aggregations.when.value > 10000` },
+      script: { lang: 'painless', source: `return ctx.results[0].aggregations.when.value == null ? false : ctx.results[0].aggregations.when.value > 10000` },
     });
   });
 });


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/issues/22

*Description of changes:*
When doing an aggregation, if there are no documents matching the query then the aggregation value will be null. This was causing error alerts since we were trying to compare null against a number. This fixes it by first checking if the value is null and if it is returning false.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
