### PR TITLE
Set min property on interval input

### DIFF
--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/Interval.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/Interval.js
@@ -41,7 +41,7 @@ const Interval = () => (
           isInvalid,
           error: hasError,
         }}
-        inputProps={{ icon: 'clock' }}
+        inputProps={{ icon: 'clock', min: 1 }}
       />
     </EuiFlexItem>
     <EuiFlexItem style={{ margin: '0px' }}>

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/__snapshots__/Frequencies.test.js.snap
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/__snapshots__/Frequencies.test.js.snap
@@ -250,6 +250,7 @@ exports[`Frequencies renders FrequencyPicker 1`] = `
         >
           <input
             class="euiFieldNumber euiFieldNumber--withIcon"
+            min="1"
             name="period.interval"
             type="number"
             value="1"
@@ -380,6 +381,7 @@ exports[`Frequencies renders Interval 1`] = `
         >
           <input
             class="euiFieldNumber euiFieldNumber--withIcon"
+            min="1"
             name="period.interval"
             type="number"
             value="1"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/issues/19

*Description of changes:*
Sets a min property in the input element for interval so arrow button/keys don't allow you to go below 1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
