### PR TITLE
Fix invalid value for new parameters and headers on Custom Destination

### DIFF
--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/HeaderParamsEditor.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/HeaderParamsEditor.js
@@ -68,7 +68,7 @@ const HeaderParamsEditor = ({ type, headerParams }) => (
       validateOnChange={true}
       render={arrayHelpers => (
         <AttributeEditor
-          onAdd={() => arrayHelpers.push({})}
+          onAdd={() => arrayHelpers.push({ key: "", value: "" })}
           onRemove={index => index !== 0 && arrayHelpers.remove(index)}
           items={headerParams}
           name={`${type}.headerParams`}

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/HeaderParamsEditor.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/HeaderParamsEditor.js
@@ -68,7 +68,7 @@ const HeaderParamsEditor = ({ type, headerParams }) => (
       validateOnChange={true}
       render={arrayHelpers => (
         <AttributeEditor
-          onAdd={() => arrayHelpers.push({ key: "", value: "" })}
+          onAdd={() => arrayHelpers.push({ key: '', value: '' })}
           onRemove={index => index !== 0 && arrayHelpers.remove(index)}
           items={headerParams}
           name={`${type}.headerParams`}

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/QueryParamsEditor.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/QueryParamsEditor.js
@@ -64,7 +64,7 @@ const QueryParamsEditor = ({ type, queryParams }) => (
     render={arrayHelpers => (
       <AttributeEditor
         titleText="Query parameters"
-        onAdd={() => arrayHelpers.push({ key: "", value: "" })}
+        onAdd={() => arrayHelpers.push({ key: '', value: '' })}
         onRemove={index => arrayHelpers.remove(index)}
         items={queryParams}
         name={`${type}.queryParams`}

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/QueryParamsEditor.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/QueryParamsEditor.js
@@ -64,7 +64,7 @@ const QueryParamsEditor = ({ type, queryParams }) => (
     render={arrayHelpers => (
       <AttributeEditor
         titleText="Query parameters"
-        onAdd={() => arrayHelpers.push({})}
+        onAdd={() => arrayHelpers.push({ key: "", value: "" })}
         onRemove={index => arrayHelpers.remove(index)}
         items={queryParams}
         name={`${type}.queryParams`}


### PR DESCRIPTION
Related to issue #71 

*Description of changes:*
Change the empty object **{}** to **{ key: "", value: "" }** when push new parameters and headers on form.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
