### PR TITLE
Bump fstream from 1.0.11 to 1.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "lodash": "^4.17.13",
     "query-string": "5.1.1",
     "react-router-dom": "4.3.1"
+  },
+  "resolutions": {
+    "fstream": "1.0.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,10 +1721,10 @@ fsevents@^1.2.7:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
-fstream@^1.0.0, fstream@^1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
-  integrity sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=
+fstream@1.0.12, fstream@^1.0.0, fstream@^1.0.2:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
   dependencies:
     graceful-fs "^4.1.2"
     inherits "~2.0.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump fstream from 1.0.11 to 1.0.12

*Test output*:
```
Test Suites: 6 skipped, 71 passed, 71 of 77 total
Tests:       21 skipped, 343 passed, 364 total
Snapshots:   121 passed, 121 total
Time:        46.813s
Ran all test suites.
✨  Done in 48.30s.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
