### PR TITLE
Allow for http method selection in custom webhook

### DIFF
--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/CustomWebhook.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/CustomWebhook.js
@@ -17,6 +17,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { EuiSpacer } from '@elastic/eui';
 import HeaderParamsEditor from './HeaderParamsEditor';
+import MethodEditor from './MethodEditor';
 import URLInfo from './URLInfo';
 
 const propTypes = {
@@ -25,6 +26,8 @@ const propTypes = {
 const CustomWebhook = ({ type, values }) => (
   <div>
     <URLInfo type={type} values={values} />
+    <EuiSpacer size="m" />
+    <MethodEditor type={type} />
     <EuiSpacer size="m" />
     <HeaderParamsEditor type={type} headerParams={values[type].headerParams} />
   </div>

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/HeaderParamsEditor.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/HeaderParamsEditor.js
@@ -34,7 +34,7 @@ const handleRenderKeyField = (fieldName, index) => (
     }}
     inputProps={{
       isInvalid,
-      disabled: index === 0, //Content-Type should be provided
+      disabled: false,
     }}
     name={fieldName}
   />

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/MethodEditor.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/MethodEditor.js
@@ -5,7 +5,7 @@ import SubHeader from '../../../../../components/SubHeader';
 import { FormikSelect } from '../../../../../components/FormControls';
 
 
-const methodOptions = [{ value: 'POST', text: 'POST' }, { value: 'PUT', text: 'PUT' }, { value: 'GET', text: 'GET' }, { value: 'DELETE', text: 'DELETE' }];
+const methodOptions = [{ value: 'POST', text: 'POST' }, { value: 'PUT', text: 'PUT' }, { value: 'PATCH', text: 'PATCH' }, { value: 'GET', text: 'GET' }, { value: 'DELETE', text: 'DELETE' }];
 
 
 

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/MethodEditor.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/MethodEditor.js
@@ -5,7 +5,7 @@ import SubHeader from '../../../../../components/SubHeader';
 import { FormikSelect } from '../../../../../components/FormControls';
 
 
-const methodOptions = [{ value: 'POST', text: 'POST' }, { value: 'PUT', text: 'PUT' }, { value: 'PATCH', text: 'PATCH' }, { value: 'GET', text: 'GET' }, { value: 'DELETE', text: 'DELETE' }];
+const methodOptions = [{ value: 'POST', text: 'POST' }, { value: 'PUT', text: 'PUT' }, { value: 'PATCH', text: 'PATCH' }];
 
 
 

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/MethodEditor.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/MethodEditor.js
@@ -1,0 +1,33 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { FieldArray } from 'formik';
+import SubHeader from '../../../../../components/SubHeader';
+import { FormikSelect } from '../../../../../components/FormControls';
+
+
+const methodOptions = [{ value: 'POST', text: 'POST' }, { value: 'PUT', text: 'PUT' }, { value: 'GET', text: 'GET' }, { value: 'DELETE', text: 'DELETE' }];
+
+
+
+const propTypes = {
+    type: PropTypes.string.isRequired,
+};
+const MethodEditor = ({ type }) => (
+<Fragment>
+    <SubHeader title={<h6>Method Selection</h6>} description={''} />
+    <FormikSelect
+        name={`${type}.method`}
+        formRow
+        rowProps={{
+            label: 'Method',
+            style: { paddingLeft: '10px' },
+        }}
+        inputProps={{
+            disabled: false,
+            options: methodOptions,
+        }}
+    />
+</Fragment>
+);
+      
+export default MethodEditor;

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/MethodEditor.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/MethodEditor.js
@@ -29,5 +29,7 @@ const MethodEditor = ({ type }) => (
     />
 </Fragment>
 );
+
+MethodEditor.propTypes = propTypes;
       
 export default MethodEditor;

--- a/public/pages/Destinations/containers/CreateDestination/utils/__tests__/destinationToFormik.test.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/__tests__/destinationToFormik.test.js
@@ -49,6 +49,7 @@ describe('destinationToFormik', () => {
         [DESTINATION_TYPE.CUSTOM_HOOK]: {
           url: 'https://custom.webhook',
           port: -1,
+          method: 'PUT',     
           query_params: { key1: 'value1', key2: 'Value2' },
           header_params: {
             'Content-Type': 'application/json',
@@ -67,6 +68,7 @@ describe('destinationToFormik', () => {
         [DESTINATION_TYPE.CUSTOM_HOOK]: {
           url: 'https://custom.webhook',
           port: 8888,
+          method: 'PUT',
           query_params: { key1: 'value1', key2: 'Value2' },
           header_params: {
             'Content-Type': 'application/json',
@@ -86,6 +88,7 @@ describe('destinationToFormik', () => {
           host: 'https://custom.webhook',
           port: 80,
           path: '/my_custom_path',
+          method: 'PUT',
           query_params: { key1: 'value1', key2: 'Value2' },
           header_params: {
             'Content-Type': 'application/json',

--- a/public/pages/Destinations/containers/CreateDestination/utils/__tests__/formikToDestination.test.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/__tests__/formikToDestination.test.js
@@ -45,6 +45,7 @@ describe('formikToDestination', () => {
         type: DESTINATION_TYPE.CUSTOM_HOOK,
         [DESTINATION_TYPE.CUSTOM_HOOK]: {
           url: 'https://custom.webhook',
+          method: 'PUT',
           queryParams: [
             {
               key: 'key1',

--- a/public/pages/Destinations/containers/CreateDestination/utils/constants.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/constants.js
@@ -37,6 +37,7 @@ export const formikInitialValues = {
   [DESTINATION_TYPE.CUSTOM_HOOK]: {
     urlType: URL_TYPE.FULL_URL,
     scheme: 'HTTPS',
+    method: 'POST',
     headerParams: [
       {
         key: CONTENT_TYPE_KEY,


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
Adds a dropdown to the custom webhook construction page that allows the user to choose the HTTP method to use.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
