### PR TITLE
validateUrl: Increasing valid TLD length to 63

### DIFF
--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.js
@@ -19,7 +19,7 @@ export const validateUrl = (value, allValues) => {
   const type = allValues.type;
   if (allValues[type].urlType !== URL_TYPE.FULL_URL) return;
   if (!value) return 'Required';
-  const regname = '((www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,4})';
+  const regname = '((www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,63})';
   const ipv4 = '(((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))';
   const h16 = '([0-9a-fA-F]{1,4})';
   const ls32 = `((${h16}:${h16})|${ipv4})`;

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.test.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.test.js
@@ -40,6 +40,7 @@ describe('validateUrl', () => {
     expect(validateUrl("https://[::ff]", typeFullUrl)).toBeUndefined();
     expect(validateUrl("https://[2001:db8::ff00:42:8329]:443/?foo=bar", typeFullUrl)).toBeUndefined();
     expect(validateUrl("http://[64:ff9b::192.0.2.128]:80/", typeFullUrl)).toBeUndefined();
+    expect(validateUrl("https://org.example/", typeFullUrl)).toBeUndefined();
   });
 
   test('returns error string if invalid', () => {

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.test.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.test.js
@@ -54,5 +54,6 @@ describe('validateUrl', () => {
     expect(validateUrl("2001:0db8:85a3:0000:0000:0000:0000:7344", typeFullUrl)).toBe(invalidText);
     expect(validateUrl("http://2001:0db8:85a3:0000:0000:0000:0000:7344", typeFullUrl)).toBe(invalidText);
     expect(validateUrl("http://[2001:0db8:85a3:0000:0r00:0000:0000:7344]", typeFullUrl)).toBe(invalidText);
+    expect(validateUrl("http://org.exampleexampleexampleexampleexampleexampleexampleexampleexampleexampleexampleexample", typeFullUrl)).toBe(invalidText);
   });
 });


### PR DESCRIPTION
According to RFC1035 (https://tools.ietf.org/html/rfc1035), the maximum size of a label is 63 octets.

We need this increased because we use a TLD that is larger than 4 characters. We cannot setup alerts as a result.

*Description of changes:*
This updates the `validateUrl` function to accept urls with TLDs up to 63 octets (consist with the RFC1035)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
