### PR TITLE
Allow longer FQDN and IPv4/v6 in host field

### DIFF
--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.js
@@ -15,7 +15,8 @@
 
 import { URL_TYPE } from '../../../containers/CreateDestination/utils/constants';
 
-const regname = '((www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,63})';
+const fqdn = '(?:[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(?:\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})*)'
+const regname = `(?:[a-zA-Z0-9._-]+(?::[^@]*)?@)?${fqdn}`;
 const ipv4 = '(((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))';
 const h16 = '([0-9a-fA-F]{1,4})';
 const ls32 = `((${h16}:${h16})|${ipv4})`;
@@ -44,7 +45,7 @@ export const validateHost = (value, allValues) => {
   const type = allValues.type;
   if (allValues[type].urlType !== URL_TYPE.ATTRIBUTE_URL) return;
   if (!value) return 'Required';
-  const regexHost = `^${regname}|${ipv4}|${ipv6}$`
+  const regexHost = `^${fqdn}|${ipv4}|${ipv6}$`
   const isValidUrl = new RegExp(regexHost).test(value);
   if (!isValidUrl) return 'Invalid Host';
 };

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.js
@@ -15,25 +15,26 @@
 
 import { URL_TYPE } from '../../../containers/CreateDestination/utils/constants';
 
+const regname = '((www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,63})';
+const ipv4 = '(((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))';
+const h16 = '([0-9a-fA-F]{1,4})';
+const ls32 = `((${h16}:${h16})|${ipv4})`;
+const ipv6 = `\\[(`+
+  `((${h16}:){6}${ls32})|`+
+  `(::(${h16}:){5}${ls32})|`+
+  `(${h16}?::(${h16}:){4}${ls32})|`+
+  `(((${h16}:){0,1}${h16})?::(${h16}:){3}${ls32})|`+
+  `(((${h16}:){0,2}${h16})?::(${h16}:){2}${ls32})|`+
+  `(((${h16}:){0,3}${h16})?::${h16}:${ls32})|`+
+  `(((${h16}:){0,4}${h16})?::${ls32})|`+
+  `(((${h16}:){0,5}${h16})?::${h16})|`+
+  `((${h16}:){0,6}${h16})?::`+
+  `)\\]`;
+
 export const validateUrl = (value, allValues) => {
   const type = allValues.type;
   if (allValues[type].urlType !== URL_TYPE.FULL_URL) return;
   if (!value) return 'Required';
-  const regname = '((www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,63})';
-  const ipv4 = '(((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))';
-  const h16 = '([0-9a-fA-F]{1,4})';
-  const ls32 = `((${h16}:${h16})|${ipv4})`;
-  const ipv6 = `\\[(`+
-    `((${h16}:){6}${ls32})|`+
-    `(::(${h16}:){5}${ls32})|`+
-    `(${h16}?::(${h16}:){4}${ls32})|`+
-    `(((${h16}:){0,1}${h16})?::(${h16}:){3}${ls32})|`+
-    `(((${h16}:){0,2}${h16})?::(${h16}:){2}${ls32})|`+
-    `(((${h16}:){0,3}${h16})?::${h16}:${ls32})|`+
-    `(((${h16}:){0,4}${h16})?::${ls32})|`+
-    `(((${h16}:){0,5}${h16})?::${h16})|`+
-    `((${h16}:){0,6}${h16})?::`+
-    `)\\]`;
   const regexUrl = `^https?:\\/\\/(${regname}|${ipv4}|${ipv6})(:[0-9]{1,5})?([/?#][-a-zA-Z0-9@:%_\\+.~#?&//=]*)?$`;
   const isValidUrl = new RegExp(regexUrl).test(value);
   if (!isValidUrl) return 'Invalid URL';
@@ -43,8 +44,7 @@ export const validateHost = (value, allValues) => {
   const type = allValues.type;
   if (allValues[type].urlType !== URL_TYPE.ATTRIBUTE_URL) return;
   if (!value) return 'Required';
-  const isValidUrl = /^(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/.test(
-    value
-  );
+  const regexHost = `^${regname}|${ipv4}|${ipv6}$`
+  const isValidUrl = new RegExp(regexHost).test(value);
   if (!isValidUrl) return 'Invalid Host';
 };

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.test.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.test.js
@@ -32,6 +32,12 @@ describe('validateUrl', () => {
     expect(
       validateUrl('https://opendistro.github.io/for-elasticsearch/news.html', typeFullUrl)
     ).toBeUndefined();
+    expect(
+      validateUrl('https://username:password@opendistro.github.io/for-elasticsearch/news.html', typeFullUrl)
+    ).toBeUndefined();
+    expect(
+      validateUrl('http://alerts-smtp-forwarder:8080/email', typeFullUrl)
+    ).toBeUndefined();
     expect(validateUrl('http://127.0.0.1:8080/', typeFullUrl)).toBeUndefined();
     expect(
       validateUrl('http://192.168.0.1/test.php?foo=bar&action=test', typeFullUrl)
@@ -82,6 +88,9 @@ describe('validateHost', () => {
   test('returns undefined if valid', () => {
     expect(
       validateHost('opendistro.github.io', typeAttributeUrl)
+    ).toBeUndefined();
+    expect(
+      validateHost('alerts-smtp-forwarder', typeAttributeUrl)
     ).toBeUndefined();
     expect(validateHost('127.0.0.1', typeAttributeUrl)).toBeUndefined();
     expect(

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.test.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.test.js
@@ -71,3 +71,35 @@ describe('validateUrl', () => {
     ).toBe(invalidText);
   });
 });
+
+describe('validateHost', () => {
+  const typeAttributeUrl = { type: 'custom_webhook', custom_webhook: { urlType: URL_TYPE.ATTRIBUTE_URL } };
+
+  test('returns Required if is empty', () => {
+    expect(validateHost('', typeAttributeUrl)).toBe('Required');
+  });
+
+  test('returns undefined if valid', () => {
+    expect(
+      validateHost('opendistro.github.io', typeAttributeUrl)
+    ).toBeUndefined();
+    expect(validateHost('127.0.0.1', typeAttributeUrl)).toBeUndefined();
+    expect(
+      validateHost('2001:0db8:85a3:0000:0000:0000:0000:7344', typeAttributeUrl)
+    ).toBeUndefined();
+    expect(validateHost('2001:0db8:85a3:0:0:0:0:7344', typeAttributeUrl)).toBeUndefined();
+    expect(validateHost('2001:0db8:85a3::7344', typeAttributeUrl)).toBeUndefined();
+    expect(validateHost('::ff', typeAttributeUrl)).toBeUndefined();
+    expect(validateHost('org.example', typeAttributeUrl)).toBeUndefined();
+  });
+
+  test('returns error string if invalid', () => {
+    const invalidText = 'Invalid Host';
+    expect(
+      validateHost(
+        'org.exampleexampleexampleexampleexampleexampleexampleexampleexampleexampleexampleexample',
+        typeAttributeUrl
+      )
+    ).toBe(invalidText);
+  });
+});


### PR DESCRIPTION
This PR should fix the following issues :

* issue #14 
* issue #103 
* issue #127 

It is complementary to the PR #115 since it fixed the domain name only for the full URL field and not also for the standalone domain field.

For better code reuse, I moved the various regexes from the `validateURL` method out of it in order to mutualize them with the `validateHost` method. That way, the same regexes are used to validate both the standalone _Host_ field and the hostname/ip in the full URL field.

Entering hostname, IPv4 or IPv6 is now valid in the standalone _Host_ field.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
