### PR TITLE
Change pull_request to push event

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -1,6 +1,6 @@
 name: Unit tests workflow
 on:
-  pull_request:
+  push:
     branches:
       - master
 


### PR DESCRIPTION
This workflow cannot successfully run when a PR is made from a fork as it does not have access to the secret to pull down the private Kibana repository. Will change it to be push instead so it can run once PR is merged.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
