### PR TITLE
fix wrong interval unit for monitor on top of anomaly detector (#145)

### DIFF
--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/AnomalyDetectors.js
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/AnomalyDetectors.js
@@ -92,7 +92,7 @@ class AnomalyDetectors extends React.Component {
               form.setFieldValue('detectorId', get(options, '0.value', ''));
               form.setFieldValue('period', {
                 interval: 2 * get(options, '0.interval.period.interval'),
-                unit: get(options, '0.interval.period.unit'),
+                unit: get(options, '0.interval.period.unit', 'MINUTES').toUpperCase(),
               });
             },
             singleSelection: { asPlaintext: true },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Merge into 1.7: fix wrong interval unit for monitor on top of anomaly detector

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
