### PR TITLE
Adds support for Kibana 7.7.0

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: opendistro-for-elasticsearch/kibana-oss
-          ref: 7.6.1
+          ref: 7.7.0
           token: ${{ secrets.GITHUB_KIBANA_OSS }}
           path: kibana
       - name: Get node and yarn versions

--- a/opendistro-elasticsearch-alerting-kibana.release-notes.md
+++ b/opendistro-elasticsearch-alerting-kibana.release-notes.md
@@ -1,3 +1,8 @@
+## Version 1.8.0.0, 2020-05-19
+
+### Bug fixes
+   * Fixes wrong time interval unit for monitor on top of anomaly detector. - [PR #145](https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/pull/145)
+
 ## Version 1.7.0.0, 2020-05-04
 
 ### New Features

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "opendistro-alerting",
-  "version": "1.7.0.0",
+  "version": "1.8.0.0",
   "description": "Kibana Alerting Plugin",
   "main": "index.js",
   "license": "Apache-2.0",
   "homepage": "https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin",
   "kibana": {
-    "version": "7.6.1",
+    "version": "7.7.0",
     "templateVersion": "6.3.3"
   },
   "repository": {

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/AnomaliesChart/AnomaliesChart.js
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/AnomaliesChart/AnomaliesChart.js
@@ -23,7 +23,6 @@ import {
   niceTimeFormatter,
   Settings,
   Position,
-  getAnnotationId,
   LineAnnotation,
 } from '@elastic/charts';
 import { ChartContainer } from '../../../../../components/ChartContainer/ChartContainer';
@@ -69,7 +68,7 @@ const AnomaliesChart = props => {
                 />
                 {props.annotationData ? (
                   <LineAnnotation
-                    annotationId={getAnnotationId('anomalyAnnotation')}
+                    annotationId="anomalyAnnotation"
                     domainType="yDomain"
                     dataValues={props.annotationData}
                     style={{

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/AnomaliesChart/AnomaliesChart.js
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/AnomaliesChart/AnomaliesChart.js
@@ -18,9 +18,7 @@ import PropTypes from 'prop-types';
 import { EuiText, EuiSpacer } from '@elastic/eui';
 import {
   Chart,
-  getAxisId,
   Axis,
-  getSpecId,
   LineSeries,
   niceTimeFormatter,
   Settings,
@@ -62,9 +60,9 @@ const AnomaliesChart = props => {
                     showLegendDisplayValue={false}
                   />
                 ) : null}
-                <Axis id={getAxisId('bottom')} position="bottom" tickFormat={timeFormatter} />
+                <Axis id="bottom" position="bottom" tickFormat={timeFormatter} />
                 <Axis
-                  id={getAxisId('left')}
+                  id="left"
                   title={getAxisTitle(props.displayGrade, props.displayConfidence)}
                   position="left"
                   domain={{ min: 0, max: 1 }}
@@ -84,7 +82,7 @@ const AnomaliesChart = props => {
                 ) : null}
                 {props.displayGrade ? (
                   <LineSeries
-                    id={getSpecId('Anomaly grade')}
+                    id="Anomaly grade"
                     xScaleType="time"
                     yScaleType="linear"
                     xAccessor={'plotTime'}
@@ -94,7 +92,7 @@ const AnomaliesChart = props => {
                 ) : null}
                 {props.displayConfidence ? (
                   <LineSeries
-                    id={getSpecId('Confidence')}
+                    id="Confidence"
                     xScaleType="time"
                     yScaleType="linear"
                     xAccessor={'plotTime'}

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/FeatureChart/FeatureChart.js
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/FeatureChart/FeatureChart.js
@@ -22,7 +22,6 @@ import {
   getSpecId,
   getAxisId,
   RectAnnotation,
-  getAnnotationId,
   niceTimeFormatter,
 } from '@elastic/charts';
 import { EuiPagination, EuiText, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
@@ -70,7 +69,7 @@ class FeatureChart extends React.Component {
                 <Chart>
                   <RectAnnotation
                     dataValues={annotations || []}
-                    annotationId={getAnnotationId('react')}
+                    annotationId="react"
                     style={{
                       stroke: '#FCAAAA',
                       strokeWidth: 1.5,

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/FeatureChart/FeatureChart.js
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/FeatureChart/FeatureChart.js
@@ -15,15 +15,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Chart,
-  Axis,
-  LineSeries,
-  getSpecId,
-  getAxisId,
-  RectAnnotation,
-  niceTimeFormatter,
-} from '@elastic/charts';
+import { Chart, Axis, LineSeries, RectAnnotation, niceTimeFormatter } from '@elastic/charts';
 import { EuiPagination, EuiText, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import DelayedLoader from '../../../../../components/DelayedLoader';
 import { ChartContainer } from '../../../../../components/ChartContainer/ChartContainer';
@@ -76,10 +68,10 @@ class FeatureChart extends React.Component {
                       fill: '#FCAAAA',
                     }}
                   />
-                  <Axis id={getAxisId('left')} title={currentFeature.featureName} position="left" />
-                  <Axis id={getAxisId('bottom')} position="bottom" tickFormat={timeFormatter} />
+                  <Axis id="left" title={currentFeature.featureName} position="left" />
+                  <Axis id="bottom" position="bottom" tickFormat={timeFormatter} />
                   <LineSeries
-                    id={getSpecId('lines')}
+                    id="lines"
                     xScaleType="time"
                     yScaleType="linear"
                     xAccessor={'startTime'}

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/__snapshots__/Frequencies.test.js.snap
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/__snapshots__/Frequencies.test.js.snap
@@ -98,6 +98,7 @@ exports[`Frequencies renders CustomCron 1`] = `
                   style="font-size:14px;display:inline-block"
                 >
                   <input
+                    aria-controls=""
                     data-test-subj="comboBoxSearchInput"
                     id="timezone"
                     role="textbox"

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/__snapshots__/AnomalyDetector.test.js.snap
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/__snapshots__/AnomalyDetector.test.js.snap
@@ -639,6 +639,7 @@ exports[`AnomalyDetectors renders 1`] = `
                         onFocus={[Function]}
                       >
                         <EuiComboBox
+                          async={false}
                           compressed={false}
                           fullWidth={false}
                           id="detectorId"
@@ -666,7 +667,6 @@ exports[`AnomalyDetectors renders 1`] = `
                             <EuiComboBoxInput
                               autoSizeInputRef={[Function]}
                               compressed={false}
-                              focusedOptionId={null}
                               fullWidth={false}
                               hasSelectedOptions={false}
                               id="detectorId"
@@ -717,7 +717,7 @@ exports[`AnomalyDetectors renders 1`] = `
                                       className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
                                       data-test-subj="comboBoxInput"
                                       onClick={[Function]}
-                                      tabIndex="-1"
+                                      tabIndex={-1}
                                     >
                                       <p
                                         className="euiComboBoxPlaceholder"
@@ -725,8 +725,7 @@ exports[`AnomalyDetectors renders 1`] = `
                                         Select a detector
                                       </p>
                                       <AutosizeInput
-                                        aria-activedescendant={null}
-                                        aria-controls={null}
+                                        aria-controls=""
                                         className="euiComboBox__input"
                                         data-test-subj="comboBoxSearchInput"
                                         id="detectorId"
@@ -754,8 +753,7 @@ exports[`AnomalyDetectors renders 1`] = `
                                           }
                                         >
                                           <input
-                                            aria-activedescendant={null}
-                                            aria-controls={null}
+                                            aria-controls=""
                                             data-test-subj="comboBoxSearchInput"
                                             id="detectorId"
                                             onBlur={[Function]}

--- a/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
@@ -664,7 +664,6 @@ exports[`MonitorIndex renders 1`] = `
                           <EuiComboBoxInput
                             autoSizeInputRef={[Function]}
                             compressed={false}
-                            focusedOptionId={null}
                             fullWidth={false}
                             hasSelectedOptions={false}
                             id="index"
@@ -712,7 +711,7 @@ exports[`MonitorIndex renders 1`] = `
                                     className="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
                                     data-test-subj="comboBoxInput"
                                     onClick={[Function]}
-                                    tabIndex="-1"
+                                    tabIndex={-1}
                                   >
                                     <p
                                       className="euiComboBoxPlaceholder"
@@ -720,8 +719,7 @@ exports[`MonitorIndex renders 1`] = `
                                       Select indices
                                     </p>
                                     <AutosizeInput
-                                      aria-activedescendant={null}
-                                      aria-controls={null}
+                                      aria-controls=""
                                       className="euiComboBox__input"
                                       data-test-subj="comboBoxSearchInput"
                                       id="index"
@@ -749,8 +747,7 @@ exports[`MonitorIndex renders 1`] = `
                                         }
                                       >
                                         <input
-                                          aria-activedescendant={null}
-                                          aria-controls={null}
+                                          aria-controls=""
                                           data-test-subj="comboBoxSearchInput"
                                           id="index"
                                           onBlur={[Function]}

--- a/public/pages/Monitors/components/AcknowledgeModal/__snapshots__/AcknowledgeModal.test.js.snap
+++ b/public/pages/Monitors/components/AcknowledgeModal/__snapshots__/AcknowledgeModal.test.js.snap
@@ -3,7 +3,6 @@
 exports[`AcknowledgeModal renders 1`] = `
 <EuiOverlayMask>
   <EuiConfirmModal
-    buttonColor="primary"
     cancelButtonText="cancel"
     confirmButtonText="Acknowledge"
     maxWidth={650}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,7 +16,7 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
-"@babel/core@^7.9.0":
+"@babel/core@^7.5.5":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.6.tgz#d9aa1f580abf3b2286ef40b6904d390904c63376"
   integrity sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==
@@ -1151,15 +1151,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
+commander@^2.20.0, commander@^2.9.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
-commander@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
-  integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
 
 commondir@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/issues/150

*Description of changes:*
- Update the plugin version to 1.8.0.0 in `package.json`
- Update Kibana version to 7.7.0 in `package.json`
- Remove usage of the deprecated `getAxisId`, `getSpecId`, and `getAnnotationId` getters from `Elastic Charts` module (https://github.com/elastic/elastic-charts/pull/554)
- Update the Release Notes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
