### PR TITLE
Fix the unit-test workflow by checking out the repo first

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -9,6 +9,10 @@ jobs:
     name: Run unit tests
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Alerting Kibana plugin
+        uses: actions/checkout@v2
+        with:
+          path: alerting-kibana-plugin
       - name: Get Kibana version
         id: kibana_version
         run: |
@@ -35,12 +39,10 @@ jobs:
           npm uninstall -g yarn
           echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
-      - name: Checkout Alerting Kibana plugin
-        uses: actions/checkout@v2
-        with:
-          path: kibana/plugins/alerting-kibana-plugin
       - name: Bootstrap plugin/kibana
         run: |
+          mkdir -p kibana/plugins
+          mv alerting-kibana-plugin kibana/plugins
           cd kibana/plugins/alerting-kibana-plugin
           yarn kbn bootstrap
       - name: Run tests


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix the unit-test workflow which is broke by my last PR, and this time I fully copied the script from ISM Kibana plugin and understood.
https://github.com/opendistro-for-elasticsearch/index-management-kibana-plugin/blob/master/.github/workflows/unit-tests-workflow.yml

Seeing from the last workflow running history,
https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/actions/runs/147988559,
I wanted to read the Kibana version from `package.json` file before I checked out the repo, and it caused the failure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
