### PR TITLE
Show error message for the failed monitor runs in dashboard

### DIFF
--- a/public/pages/Dashboard/utils/tableUtils.js
+++ b/public/pages/Dashboard/utils/tableUtils.js
@@ -18,10 +18,10 @@ import _ from 'lodash';
 import { EuiLink } from '@elastic/eui';
 import moment from 'moment';
 
-import { DEFAULT_EMPTY_DATA } from '../../../utils/constants';
+import { ALERT_STATE, DEFAULT_EMPTY_DATA } from '../../../utils/constants';
 import { PLUGIN_NAME } from '../../../../utils/constants';
 
-const renderTime = time => {
+const renderTime = (time) => {
   const momentTime = moment(time);
   if (time && momentTime.isValid()) return momentTime.format('MM/DD/YY h:mm a');
   return DEFAULT_EMPTY_DATA;
@@ -72,8 +72,11 @@ export const columns = [
     name: 'State',
     sortable: false,
     truncateText: false,
-    render: state =>
-      typeof state !== 'string' ? DEFAULT_EMPTY_DATA : _.capitalize(state.toLowerCase()),
+    render: (state, alert) => {
+      const stateText =
+        typeof state !== 'string' ? DEFAULT_EMPTY_DATA : _.capitalize(state.toLowerCase());
+      return state === ALERT_STATE.ERROR ? `${stateText}: ${alert.error_message}` : stateText;
+    },
   },
   {
     field: 'acknowledged_time',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently if there is an error occurs in monitor runs, it just shown as `Error`, the error message is missing. This PR will make it shown as `Error: <error message>`.

- In Dashboard
![image](https://user-images.githubusercontent.com/62041081/92872454-e7676100-f3ba-11ea-8517-d33a801d79c1.png)

- In Monitor Detail page
![image](https://user-images.githubusercontent.com/62041081/92874792-37dfbe00-f3bd-11ea-9489-6ed1b8320157.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
