### PR TITLE
Add features of showing error messages to 'opendistro-1.9_security_testing' branch

### DIFF
--- a/public/pages/CreateMonitor/containers/ConfigureMonitor/ConfigureMonitor.js
+++ b/public/pages/CreateMonitor/containers/ConfigureMonitor/ConfigureMonitor.js
@@ -18,7 +18,7 @@ import { EuiSpacer } from '@elastic/eui';
 
 import ContentPanel from '../../../../components/ContentPanel';
 import MonitorState from '../../components/MonitorState';
-import { hasError, isInvalid, validateMonitorName } from '../../../../utils/validate';
+import { hasError, isInvalid, required, validateMonitorName } from '../../../../utils/validate';
 import FormikFieldText from '../../../../components/FormControls/FormikFieldText';
 
 const ConfigureMonitor = ({ httpClient, monitorToEdit }) => (
@@ -35,8 +35,12 @@ const ConfigureMonitor = ({ httpClient, monitorToEdit }) => (
       }}
       inputProps={{
         isInvalid,
-        onFocus: (e, field, form) => {
-          form.setFieldError('name', undefined);
+        /* To reduce the frequency of search request,
+        the comprehensive 'validationMonitorName()' is only called onBlur,
+        but we enable the basic 'required()' validation onChange for good user experience.*/
+        onChange: (e, field, form) => {
+          field.onChange(e);
+          form.setFieldError('name', required(e.target.value));
         },
       }}
     />

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
@@ -35,6 +35,7 @@ import { formikToMonitor } from './utils/formikToMonitor';
 import { DefineSchedule } from '../DefineSchedule';
 import { TRIGGER_ACTIONS, SEARCH_TYPE } from '../../../../utils/constants';
 import { initializeFromQueryParams } from './utils/monitorQueryParams';
+import { SubmitErrorHandler } from '../../../../utils/SubmitErrorHandler';
 
 export default class CreateMonitor extends Component {
   static defaultProps = {
@@ -137,7 +138,7 @@ export default class CreateMonitor extends Component {
           initialValues={initialValues}
           onSubmit={this.onSubmit}
           validateOnChange={false}
-          render={(props) => (
+          render={({ values, errors, handleSubmit, isSubmitting, isValid }) => (
             <Fragment>
               <EuiTitle size="l">
                 <h1>{edit ? 'Edit' : 'Create'} monitor</h1>
@@ -146,14 +147,14 @@ export default class CreateMonitor extends Component {
               <ConfigureMonitor httpClient={httpClient} monitorToEdit={monitorToEdit} />
               <EuiSpacer />
               <DefineMonitor
-                values={props.values}
-                errors={props.errors}
+                values={values}
+                errors={errors}
                 httpClient={httpClient}
                 detectorId={this.props.detectorId}
               />
               <Fragment>
                 <EuiSpacer />
-                <DefineSchedule isAd={props.values.searchType === SEARCH_TYPE.AD} />
+                <DefineSchedule isAd={values.searchType === SEARCH_TYPE.AD} />
               </Fragment>
               <EuiSpacer />
               <EuiSpacer />
@@ -162,13 +163,15 @@ export default class CreateMonitor extends Component {
                   <EuiButtonEmpty onClick={this.onCancel}>Cancel</EuiButtonEmpty>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <EuiButton fill onClick={props.handleSubmit} isLoading={props.isSubmitting}>
+                  <EuiButton fill onClick={handleSubmit} isLoading={isSubmitting}>
                     {edit ? 'Update' : 'Create'}
                   </EuiButton>
                 </EuiFlexItem>
               </EuiFlexGroup>
               <SubmitErrorHandler
-                formik={props}
+                errors={errors}
+                isSubmitting={isSubmitting}
+                isValid={isValid}
                 onSubmitError={() =>
                   toastNotifications.addDanger({
                     title: 'Failed to create the monitor.',
@@ -182,17 +185,4 @@ export default class CreateMonitor extends Component {
       </div>
     );
   }
-}
-
-// This function is use to show additional error messages when validation fails on submit
-// Reference: https://github.com/formium/formik/issues/1484
-function SubmitErrorHandler(props) {
-  const { submitCount, isSubmitting, isValid } = props.formik;
-  const effect = () => {
-    if (submitCount > 0 && !isSubmitting && !isValid) {
-      props.onSubmitError();
-    }
-  };
-  React.useEffect(effect, [submitCount, isSubmitting]);
-  return null;
 }

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
@@ -90,6 +90,7 @@ export default class CreateMonitor extends Component {
         );
       } else {
         console.log('Failed to create:', resp.data);
+        this.backendErrorHandler('create', resp.data);
       }
     } catch (err) {
       console.error(err);
@@ -114,6 +115,7 @@ export default class CreateMonitor extends Component {
         this.props.history.push(`/monitors/${id}`);
       } else {
         console.log('Failed to update:', resp.data);
+        this.backendErrorHandler('update', resp.data);
       }
     } catch (err) {
       console.error(err);
@@ -127,6 +129,15 @@ export default class CreateMonitor extends Component {
     const monitor = formikToMonitor(values);
     if (edit) this.onUpdate(monitor, formikBag);
     else this.onCreate(monitor, formikBag);
+  }
+
+  backendErrorHandler(actionName, data) {
+    const errorMsg = data.resp;
+    toastNotifications.addDanger({
+      title: `Failed to ${actionName} the monitor`,
+      // remove the error type which locates before the first white space in 'errorMsg'
+      text: errorMsg.substr(errorMsg.indexOf(' ') + 1),
+    });
   }
 
   render() {
@@ -174,7 +185,7 @@ export default class CreateMonitor extends Component {
                 isValid={isValid}
                 onSubmitError={() =>
                   toastNotifications.addDanger({
-                    title: 'Failed to create the monitor.',
+                    title: `Failed to ${edit ? 'update' : 'create'} the monitor`,
                     text: 'Fix all highlighted error(s) before continuing.',
                   })
                 }

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
@@ -132,12 +132,11 @@ export default class CreateMonitor extends Component {
   }
 
   backendErrorHandler(actionName, data) {
-    const errorMsg = data.resp;
     toastNotifications.addDanger({
       title: `Failed to ${actionName} the monitor`,
-      // remove the error type which locates before the first white space in 'errorMsg'
-      text: errorMsg.substr(errorMsg.indexOf(' ') + 1),
+      text: data.resp,
     });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
   render() {

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
@@ -153,7 +153,7 @@ export default class CreateMonitor extends Component {
               />
               <Fragment>
                 <EuiSpacer />
-                <DefineSchedule isAd={values.searchType === SEARCH_TYPE.AD} />
+                <DefineSchedule isAd={props.values.searchType === SEARCH_TYPE.AD} />
               </Fragment>
               <EuiSpacer />
               <EuiSpacer />
@@ -187,10 +187,10 @@ export default class CreateMonitor extends Component {
 // This function is use to show additional error messages when validation fails on submit
 // Reference: https://github.com/formium/formik/issues/1484
 function SubmitErrorHandler(props) {
-  const { submitCount, isSubmitting, isValid, onSubmitError } = props.formik;
+  const { submitCount, isSubmitting, isValid } = props.formik;
   const effect = () => {
     if (submitCount > 0 && !isSubmitting && !isValid) {
-      onSubmitError();
+      props.onSubmitError();
     }
   };
   React.useEffect(effect, [submitCount, isSubmitting]);

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
@@ -25,6 +25,7 @@ import {
   EuiButton,
   EuiButtonEmpty,
 } from '@elastic/eui';
+import { toastNotifications } from 'ui/notify';
 
 import ConfigureMonitor from '../ConfigureMonitor';
 import DefineMonitor from '../DefineMonitor';
@@ -136,7 +137,7 @@ export default class CreateMonitor extends Component {
           initialValues={initialValues}
           onSubmit={this.onSubmit}
           validateOnChange={false}
-          render={({ values, errors, handleSubmit, isSubmitting }) => (
+          render={(props) => (
             <Fragment>
               <EuiTitle size="l">
                 <h1>{edit ? 'Edit' : 'Create'} monitor</h1>
@@ -145,8 +146,8 @@ export default class CreateMonitor extends Component {
               <ConfigureMonitor httpClient={httpClient} monitorToEdit={monitorToEdit} />
               <EuiSpacer />
               <DefineMonitor
-                values={values}
-                errors={errors}
+                values={props.values}
+                errors={props.errors}
                 httpClient={httpClient}
                 detectorId={this.props.detectorId}
               />
@@ -161,15 +162,37 @@ export default class CreateMonitor extends Component {
                   <EuiButtonEmpty onClick={this.onCancel}>Cancel</EuiButtonEmpty>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <EuiButton fill onClick={handleSubmit} isLoading={isSubmitting}>
+                  <EuiButton fill onClick={props.handleSubmit} isLoading={props.isSubmitting}>
                     {edit ? 'Update' : 'Create'}
                   </EuiButton>
                 </EuiFlexItem>
               </EuiFlexGroup>
+              <SubmitErrorHandler
+                formik={props}
+                onSubmitError={() =>
+                  toastNotifications.addDanger({
+                    title: 'Failed to create the monitor.',
+                    text: 'Fix all highlighted error(s) before continuing.',
+                  })
+                }
+              />
             </Fragment>
           )}
         />
       </div>
     );
   }
+}
+
+// This function is use to show additional error messages when validation fails on submit
+// Reference: https://github.com/formium/formik/issues/1484
+function SubmitErrorHandler(props) {
+  const { submitCount, isSubmitting, isValid, onSubmitError } = props.formik;
+  const effect = () => {
+    if (submitCount > 0 && !isSubmitting && !isValid) {
+      onSubmitError();
+    }
+  };
+  React.useEffect(effect, [submitCount, isSubmitting]);
+  return null;
 }

--- a/public/pages/Dashboard/utils/tableUtils.js
+++ b/public/pages/Dashboard/utils/tableUtils.js
@@ -18,10 +18,10 @@ import _ from 'lodash';
 import { EuiLink } from '@elastic/eui';
 import moment from 'moment';
 
-import { DEFAULT_EMPTY_DATA } from '../../../utils/constants';
+import { ALERT_STATE, DEFAULT_EMPTY_DATA } from '../../../utils/constants';
 import { PLUGIN_NAME } from '../../../../utils/constants';
 
-const renderTime = time => {
+const renderTime = (time) => {
   const momentTime = moment(time);
   if (time && momentTime.isValid()) return momentTime.format('MM/DD/YY h:mm a');
   return DEFAULT_EMPTY_DATA;
@@ -72,8 +72,11 @@ export const columns = [
     name: 'State',
     sortable: false,
     truncateText: false,
-    render: state =>
-      typeof state !== 'string' ? DEFAULT_EMPTY_DATA : _.capitalize(state.toLowerCase()),
+    render: (state, alert) => {
+      const stateText =
+        typeof state !== 'string' ? DEFAULT_EMPTY_DATA : _.capitalize(state.toLowerCase());
+      return state === ALERT_STATE.ERROR ? `${stateText}: ${alert.error_message}` : stateText;
+    },
   },
   {
     field: 'acknowledged_time',

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/URLInfo.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/URLInfo.js
@@ -21,7 +21,7 @@ import {
   FormikFieldNumber,
   FormikFieldRadio,
 } from '../../../../../components/FormControls';
-import { hasError, isInvalid } from '../../../../../utils/validate';
+import { hasError, isInvalid, required } from '../../../../../utils/validate';
 import { validateUrl, validateHost } from './validate';
 import { URL_TYPE } from '../../../containers/CreateDestination/utils/constants';
 import { formikInitialValues } from '../../../containers/CreateDestination/utils/constants';
@@ -32,7 +32,10 @@ const propTypes = {
   type: PropTypes.string.isRequired,
   values: PropTypes.object.isRequired,
 };
-const protocolOptions = [{ value: 'HTTPS', text: 'HTTPS' }, { value: 'HTTP', text: 'HTTP' }];
+const protocolOptions = [
+  { value: 'HTTPS', text: 'HTTPS' },
+  { value: 'HTTP', text: 'HTTP' },
+];
 
 const URLInfo = ({ type, values }) => {
   const isUrlEnabled = values[type].urlType === URL_TYPE.FULL_URL;
@@ -78,7 +81,7 @@ const URLInfo = ({ type, values }) => {
         name={`${type}.url`}
         formRow
         fieldProps={{
-          validate: fieldValue => validateUrl(fieldValue, values),
+          validate: (fieldValue) => validateUrl(fieldValue, values),
         }}
         rowProps={{
           label: 'Webhook URL',
@@ -89,6 +92,11 @@ const URLInfo = ({ type, values }) => {
         inputProps={{
           disabled: !isUrlEnabled,
           isInvalid,
+          // 'validateUrl()' is only called onBlur, but we enable the basic 'required()' validation onChange
+          onChange: (e, field, form) => {
+            field.onChange(e);
+            form.setFieldError(`${type}.url`, required(e.target.value));
+          },
         }}
       />
       <FormikFieldRadio
@@ -126,7 +134,7 @@ const URLInfo = ({ type, values }) => {
         name={`${type}.host`}
         formRow
         fieldProps={{
-          validate: fieldValue => validateHost(fieldValue, values),
+          validate: (fieldValue) => validateHost(fieldValue, values),
         }}
         rowProps={{
           label: 'Host',
@@ -137,8 +145,10 @@ const URLInfo = ({ type, values }) => {
         inputProps={{
           disabled: isUrlEnabled,
           isInvalid,
-          onFocus: (e, field, form) => {
-            form.setFieldError(`${type}.host`, undefined);
+          // 'validateHost()' is only called onBlur, but we enable the basic 'required()' validation onChange
+          onChange: (e, field, form) => {
+            field.onChange(e);
+            form.setFieldError(`${type}.host`, required(e.target.value));
           },
         }}
       />
@@ -170,7 +180,11 @@ const URLInfo = ({ type, values }) => {
           isInvalid,
         }}
       />
-      <QueryParamsEditor type={type} queryParams={values[type].queryParams} isEnabled={!isUrlEnabled} />
+      <QueryParamsEditor
+        type={type}
+        queryParams={values[type].queryParams}
+        isEnabled={!isUrlEnabled}
+      />
     </Fragment>
   );
 };

--- a/public/pages/Destinations/components/createDestinations/Webhook/Webhook.js
+++ b/public/pages/Destinations/components/createDestinations/Webhook/Webhook.js
@@ -16,10 +16,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormikFieldText } from '../../../../../components/FormControls';
-import { hasError, isInvalid } from '../../../../../utils/validate';
+import { hasError, isInvalid, required } from '../../../../../utils/validate';
 
 //TODO:: verify the Regex for all the cases based on what backend support
-const validateURL = value => {
+const validateURL = (value) => {
   if (!value) return 'Required';
   const isValidUrl = /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/.test(
     value
@@ -41,8 +41,10 @@ const Webhook = ({ type }) => {
       }}
       inputProps={{
         isInvalid,
-        onFocus: (e, field, form) => {
-          form.setFieldError(`${type}.url`, undefined);
+        // 'validateURL()' is only called onBlur, but we enable the basic 'required()' validation onChange
+        onChange: (e, field, form) => {
+          field.onChange(e);
+          form.setFieldError('name', required(e.target.value));
         },
       }}
     />

--- a/public/pages/Destinations/containers/CreateDestination/CreateDestination.js
+++ b/public/pages/Destinations/containers/CreateDestination/CreateDestination.js
@@ -25,6 +25,7 @@ import {
   EuiButton,
   EuiButtonEmpty,
 } from '@elastic/eui';
+import { toastNotifications } from 'ui/notify';
 import ContentPanel from '../../../../components/ContentPanel';
 import { hasError, isInvalid, required } from '../../../../utils/validate';
 import { FormikFieldText, FormikSelect } from '../../../../components/FormControls';
@@ -35,6 +36,7 @@ import { validateDestinationName } from './utils/validations';
 import { formikToDestination } from './utils/formikToDestination';
 import { destinationToFormik } from './utils/destinationToFormik';
 import { Webhook, CustomWebhook } from '../../components/createDestinations';
+import { SubmitErrorHandler } from '../../../../utils/SubmitErrorHandler';
 
 const destinationType = {
   [DESTINATION_TYPE.SLACK]: (props) => <Webhook {...props} />,
@@ -162,7 +164,7 @@ class CreateDestination extends React.Component {
           initialValues={initialValues}
           validateOnChange={false}
           onSubmit={this.handleSubmit}
-          render={({ values, handleSubmit, isSubmitting }) => (
+          render={({ values, handleSubmit, isSubmitting, errors, isValid }) => (
             <Fragment>
               <EuiTitle size="l">
                 <h1>{edit ? 'Edit' : 'Add'} destination</h1>
@@ -227,6 +229,17 @@ class CreateDestination extends React.Component {
                   </EuiButton>
                 </EuiFlexItem>
               </EuiFlexGroup>
+              <SubmitErrorHandler
+                errors={errors}
+                isSubmitting={isSubmitting}
+                isValid={isValid}
+                onSubmitError={() =>
+                  toastNotifications.addDanger({
+                    title: `Failed to ${edit ? 'update' : 'create'} the destination`,
+                    text: 'Fix all highlighted error(s) before continuing.',
+                  })
+                }
+              />
             </Fragment>
           )}
         />

--- a/public/pages/Destinations/containers/CreateDestination/CreateDestination.js
+++ b/public/pages/Destinations/containers/CreateDestination/CreateDestination.js
@@ -170,45 +170,45 @@ class CreateDestination extends React.Component {
               <EuiSpacer size="m" />
               <ContentPanel title="Destination" titleSize="s" bodyStyles={{ padding: 'initial' }}>
                 <div style={{ padding: '0px 10px' }}>
-                  <div style={{ padding: '0px 10px' }}>
-                    <FormikFieldText
-                      name="name"
-                      formRow
-                      fieldProps={{
-                        validate: validateDestinationName(
-                          httpClient,
-                          _.get(location, 'state.destinationToEdit')
-                        ),
-                      }}
-                      rowProps={{
-                        label: 'Name',
-                        helpText: 'Specify a name of the destination.',
-                        isInvalid,
-                        error: hasError,
-                      }}
-                      inputProps={{
-                        isInvalid,
-                        /* To reduce the frequency of search request,
+                  <FormikFieldText
+                    name="name"
+                    formRow
+                    fieldProps={{
+                      validate: validateDestinationName(
+                        httpClient,
+                        _.get(location, 'state.destinationToEdit')
+                      ),
+                    }}
+                    rowProps={{
+                      label: 'Name',
+                      helpText: 'Specify a name of the destination.',
+                      style: { paddingLeft: '10px' },
+                      isInvalid,
+                      error: hasError,
+                    }}
+                    inputProps={{
+                      isInvalid,
+                      /* To reduce the frequency of search request,
                       the comprehension 'validateDestinationName()' is only called onBlur,
                       but we enable the basic 'required()' validation onChange for good user experience.*/
-                        onChange: (e, field, form) => {
-                          field.onChange(e);
-                          form.setFieldError('name', required(e.target.value));
-                        },
-                      }}
-                    />
-                    <FormikSelect
-                      name="type"
-                      formRow
-                      rowProps={{
-                        label: 'Type',
-                      }}
-                      inputProps={{
-                        disabled: edit,
-                        options: DESTINATION_OPTIONS,
-                      }}
-                    />
-                  </div>
+                      onChange: (e, field, form) => {
+                        field.onChange(e);
+                        form.setFieldError('name', required(e.target.value));
+                      },
+                    }}
+                  />
+                  <FormikSelect
+                    name="type"
+                    formRow
+                    rowProps={{
+                      label: 'Type',
+                      style: { paddingLeft: '10px' },
+                    }}
+                    inputProps={{
+                      disabled: edit,
+                      options: DESTINATION_OPTIONS,
+                    }}
+                  />
                   <EuiSpacer size="m" />
                   <SubHeader title={<h4>Settings</h4>} description={''} />
                   <EuiSpacer size="m" />

--- a/public/pages/Destinations/containers/CreateDestination/CreateDestination.js
+++ b/public/pages/Destinations/containers/CreateDestination/CreateDestination.js
@@ -26,7 +26,7 @@ import {
   EuiButtonEmpty,
 } from '@elastic/eui';
 import ContentPanel from '../../../../components/ContentPanel';
-import { hasError, isInvalid } from '../../../../utils/validate';
+import { hasError, isInvalid, required } from '../../../../utils/validate';
 import { FormikFieldText, FormikSelect } from '../../../../components/FormControls';
 import SubHeader from '../../../../components/SubHeader';
 import { formikInitialValues } from './utils/constants';
@@ -37,9 +37,9 @@ import { destinationToFormik } from './utils/destinationToFormik';
 import { Webhook, CustomWebhook } from '../../components/createDestinations';
 
 const destinationType = {
-  [DESTINATION_TYPE.SLACK]: props => <Webhook {...props} />,
-  [DESTINATION_TYPE.CHIME]: props => <Webhook {...props} />,
-  [DESTINATION_TYPE.CUSTOM_HOOK]: props => <CustomWebhook {...props} />,
+  [DESTINATION_TYPE.SLACK]: (props) => <Webhook {...props} />,
+  [DESTINATION_TYPE.CHIME]: (props) => <Webhook {...props} />,
+  [DESTINATION_TYPE.CUSTOM_HOOK]: (props) => <CustomWebhook {...props} />,
 };
 
 class CreateDestination extends React.Component {
@@ -68,7 +68,7 @@ class CreateDestination extends React.Component {
     };
   }
 
-  getDestination = async destinationId => {
+  getDestination = async (destinationId) => {
     const { httpClient, history } = this.props;
     try {
       const resp = await httpClient.get(`../api/alerting/destinations/${destinationId}`);
@@ -170,38 +170,45 @@ class CreateDestination extends React.Component {
               <EuiSpacer size="m" />
               <ContentPanel title="Destination" titleSize="s" bodyStyles={{ padding: 'initial' }}>
                 <div style={{ padding: '0px 10px' }}>
-                  <FormikFieldText
-                    name="name"
-                    formRow
-                    fieldProps={{
-                      validate: validateDestinationName(
-                        httpClient,
-                        _.get(location, 'state.destinationToEdit')
-                      ),
-                    }}
-                    rowProps={{
-                      label: 'Name',
-                      helpText: 'Specify a name of the destination.',
-                      style: { paddingLeft: '10px' },
-                      isInvalid,
-                      error: hasError,
-                    }}
-                    inputProps={{
-                      isInvalid,
-                    }}
-                  />
-                  <FormikSelect
-                    name="type"
-                    formRow
-                    rowProps={{
-                      label: 'Type',
-                      style: { paddingLeft: '10px' },
-                    }}
-                    inputProps={{
-                      disabled: edit,
-                      options: DESTINATION_OPTIONS,
-                    }}
-                  />
+                  <div style={{ padding: '0px 10px' }}>
+                    <FormikFieldText
+                      name="name"
+                      formRow
+                      fieldProps={{
+                        validate: validateDestinationName(
+                          httpClient,
+                          _.get(location, 'state.destinationToEdit')
+                        ),
+                      }}
+                      rowProps={{
+                        label: 'Name',
+                        helpText: 'Specify a name of the destination.',
+                        isInvalid,
+                        error: hasError,
+                      }}
+                      inputProps={{
+                        isInvalid,
+                        /* To reduce the frequency of search request,
+                      the comprehension 'validateDestinationName()' is only called onBlur,
+                      but we enable the basic 'required()' validation onChange for good user experience.*/
+                        onChange: (e, field, form) => {
+                          field.onChange(e);
+                          form.setFieldError('name', required(e.target.value));
+                        },
+                      }}
+                    />
+                    <FormikSelect
+                      name="type"
+                      formRow
+                      rowProps={{
+                        label: 'Type',
+                      }}
+                      inputProps={{
+                        disabled: edit,
+                        options: DESTINATION_OPTIONS,
+                      }}
+                    />
+                  </div>
                   <EuiSpacer size="m" />
                   <SubHeader title={<h4>Settings</h4>} description={''} />
                   <EuiSpacer size="m" />

--- a/public/utils/SubmitErrorHandler.js
+++ b/public/utils/SubmitErrorHandler.js
@@ -1,0 +1,34 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { useEffect } from 'react';
+// This function is used to:
+// 1. call function 'onSubmitError()' when validation fails on submit
+// 2. auto scroll the page to the first field with error
+// Reference: https://github.com/formium/formik/issues/1484 and https://github.com/formium/formik/issues/146
+export const SubmitErrorHandler = (props) => {
+  const { errors, isSubmitting, isValid, onSubmitError } = props;
+  const errorKeys = Object.keys(errors);
+  const effect = () => {
+    if (errorKeys.length > 0 && !isSubmitting && !isValid) {
+      onSubmitError();
+      const selector = `[name="${errorKeys[0]}"]`;
+      const errorElement = document.querySelector(selector);
+      if (errorElement) errorElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  };
+  useEffect(effect, [isSubmitting]);
+  return null;
+};

--- a/public/utils/SubmitErrorHandler.js
+++ b/public/utils/SubmitErrorHandler.js
@@ -19,7 +19,7 @@ import { useEffect } from 'react';
  2. auto scroll the page to the first field with error, and focus the field
  Reference: https://github.com/formium/formik/issues/1484 and https://github.com/formium/formik/issues/146 */
 export const SubmitErrorHandler = (props) => {
-  const errorKeys = Object.keys(props.errors);
+  const errorKeys = Object.keys(dotNotate(props.errors));
   const effect = () => {
     if (errorKeys.length > 0 && !props.isSubmitting && !props.isValid) {
       props.onSubmitError();
@@ -36,3 +36,18 @@ export const SubmitErrorHandler = (props) => {
   useEffect(effect, [props.isSubmitting]);
   return null;
 };
+
+// convert JSON object structure to dot notation
+function dotNotate(obj, target, prefix) {
+  (target = target || {}), (prefix = prefix || '');
+
+  Object.keys(obj).forEach(function (key) {
+    if (obj[key] !== null && typeof obj[key] === 'object') {
+      dotNotate(obj[key], target, prefix + key + '.');
+    } else {
+      return (target[prefix + key] = obj[key]);
+    }
+  });
+
+  return target;
+}

--- a/public/utils/SubmitErrorHandler.js
+++ b/public/utils/SubmitErrorHandler.js
@@ -26,6 +26,7 @@ export const SubmitErrorHandler = (props) => {
       /* Use 2 selectors to locate the form elements. Because some elements only have 'name' attribute,
       some only have 'id' attribute, but are nested in a <div> with same the value in 'name' attribute. */
       const selector = `[id="${errorKeys[0]}"], [name="${errorKeys[0]}"]:not(div)`;
+      const errorElement = document.querySelector(selector);
       if (errorElement) {
         errorElement.focus();
         errorElement.scrollIntoView({ behavior: 'smooth', block: 'center' });

--- a/public/utils/SubmitErrorHandler.js
+++ b/public/utils/SubmitErrorHandler.js
@@ -19,16 +19,15 @@ import { useEffect } from 'react';
 // 2. auto scroll the page to the first field with error
 // Reference: https://github.com/formium/formik/issues/1484 and https://github.com/formium/formik/issues/146
 export const SubmitErrorHandler = (props) => {
-  const { errors, isSubmitting, isValid, onSubmitError } = props;
-  const errorKeys = Object.keys(errors);
+  const errorKeys = Object.keys(props.errors);
   const effect = () => {
-    if (errorKeys.length > 0 && !isSubmitting && !isValid) {
-      onSubmitError();
+    if (errorKeys.length > 0 && !props.isSubmitting && !props.isValid) {
+      props.onSubmitError();
       const selector = `[name="${errorKeys[0]}"]`;
       const errorElement = document.querySelector(selector);
       if (errorElement) errorElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
   };
-  useEffect(effect, [isSubmitting]);
+  useEffect(effect, [props.isSubmitting]);
   return null;
 };

--- a/public/utils/SubmitErrorHandler.js
+++ b/public/utils/SubmitErrorHandler.js
@@ -23,12 +23,9 @@ export const SubmitErrorHandler = (props) => {
   const effect = () => {
     if (errorKeys.length > 0 && !props.isSubmitting && !props.isValid) {
       props.onSubmitError();
-      /* Use 2 selectors to locate the input field. Because some <input> elements only have 'name' attribute,
-      some <input> only have 'id', but are nested in a <div> with same value in 'name' attribute. */
-      const idSelector = `[id="${errorKeys[0]}"]`;
-      const nameSelector = `[name="${errorKeys[0]}"]`;
-      const errorElement =
-        document.querySelector(idSelector) ?? document.querySelector(nameSelector);
+      /* Use 2 selectors to locate the form elements. Because some elements only have 'name' attribute,
+      some only have 'id' attribute, but are nested in a <div> with same the value in 'name' attribute. */
+      const selector = `[id="${errorKeys[0]}"], [name="${errorKeys[0]}"]:not(div)`;
       if (errorElement) {
         errorElement.focus();
         errorElement.scrollIntoView({ behavior: 'smooth', block: 'center' });

--- a/public/utils/SubmitErrorHandler.js
+++ b/public/utils/SubmitErrorHandler.js
@@ -14,18 +14,25 @@
  */
 
 import { useEffect } from 'react';
-// This function is used to:
-// 1. call function 'onSubmitError()' when validation fails on submit
-// 2. auto scroll the page to the first field with error
-// Reference: https://github.com/formium/formik/issues/1484 and https://github.com/formium/formik/issues/146
+/* This function is used to:
+ 1. call function 'onSubmitError()' when validation fails on submit
+ 2. auto scroll the page to the first field with error, and focus the field
+ Reference: https://github.com/formium/formik/issues/1484 and https://github.com/formium/formik/issues/146 */
 export const SubmitErrorHandler = (props) => {
   const errorKeys = Object.keys(props.errors);
   const effect = () => {
     if (errorKeys.length > 0 && !props.isSubmitting && !props.isValid) {
       props.onSubmitError();
-      const selector = `[name="${errorKeys[0]}"]`;
-      const errorElement = document.querySelector(selector);
-      if (errorElement) errorElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      /* Use 2 selectors to locate the input field. Because some <input> elements only have 'name' attribute,
+      some <input> only have 'id', but are nested in a <div> with same value in 'name' attribute. */
+      const idSelector = `[id="${errorKeys[0]}"]`;
+      const nameSelector = `[name="${errorKeys[0]}"]`;
+      const errorElement =
+        document.querySelector(idSelector) ?? document.querySelector(nameSelector);
+      if (errorElement) {
+        errorElement.focus();
+        errorElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
     }
   };
   useEffect(effect, [props.isSubmitting]);

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -25,6 +25,7 @@ module.exports = {
   coverageDirectory: './coverage',
   moduleNameMapper: {
     '\\.(css|less|scss)$': '<rootDir>/test/mocks/styleMock.js',
+    '^ui/(.*)': '<rootDir>/../../src/legacy/ui/public/$1/',
   },
   snapshotSerializers: ['../../node_modules/enzyme-to-json/serializer'],
   coverageReporters: ['lcov', 'text', 'cobertura'],

--- a/test/setup.jest.js
+++ b/test/setup.jest.js
@@ -26,6 +26,13 @@ jest.mock('@elastic/eui/lib/components/icon', () => ({
 
 jest.mock('@elastic/eui/lib/components/form/form_row/make_id', () => () => 'some_make_id');
 
+jest.mock('ui/notify', () => ({
+  toastNotifications: {
+    addDanger: jest.fn().mockName('addDanger'),
+    addSuccess: jest.fn().mockName('addSuccess'),
+  },
+}));
+
 // https://github.com/facebook/jest/issues/5785
 // https://github.com/facebook/jest/pull/5267#issuecomment-356605468
 beforeEach(() => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Request to merge the 2 PRs into an ODFE 1.9 testing branch: https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/pull/168, https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/pull/182
- Show error message for the failed monitor runs in dashboard
- Add a toast message and auto scroll to the 1st error field when failed to create/update a monitor or destination

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
