### PR TITLE
Show name of the user who last updated the monitor in Monitor Dashboard and Detail page

### DIFF
--- a/public/pages/MonitorDetails/components/MonitorOverview/__snapshots__/MonitorOverview.test.js.snap
+++ b/public/pages/MonitorDetails/components/MonitorOverview/__snapshots__/MonitorOverview.test.js.snap
@@ -135,6 +135,20 @@ exports[`MonitorOverview renders 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="euiFlexItem"
+      >
+        <div
+          class="euiText euiText--extraSmall"
+        >
+          <strong>
+            Last updated by
+          </strong>
+          <div>
+            N/A
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
@@ -59,6 +59,12 @@ export default function getOverviewStats(monitor, monitorId, monitorVersion, act
       value: monitorVersion,
     },
     {
+      /* There are 3 cases:
+      1. Monitors created by older versions and never updated.
+         These monitors won’t have User details in the monitor object. `monitor.user` will be null.
+      2. Monitors are created when security plugin is disabled, these will have empty User object.
+         (`monitor.user.name`, `monitor.user.roles` are empty )
+      3. Monitors are created when security plugin is enabled, these will have an User object. */
       header: 'Last updated by',
       value: monitor.user && monitor.user.name ? monitor.user.name : 'N/A',
     },

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
@@ -60,7 +60,7 @@ export default function getOverviewStats(monitor, monitorId, monitorVersion, act
     },
     {
       header: 'Last updated by',
-      value: monitor.user.name,
+      value: monitor.user && monitor.user.name ? monitor.user.name : 'N/A',
     },
   ];
 }

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
@@ -58,5 +58,9 @@ export default function getOverviewStats(monitor, monitorId, monitorVersion, act
       header: 'Monitor version number',
       value: monitorVersion,
     },
+    {
+      header: 'Last updated by',
+      value: monitor.user.name,
+    },
   ];
 }

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.test.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.test.js
@@ -20,6 +20,9 @@ describe('getOverviewStats', () => {
   test('can get stats', () => {
     const monitor = {
       enabled: true,
+      user: {
+        name: 'John Doe',
+      },
     };
     const monitorId = 'sdfifsjeifjseif';
     const monitorVersion = 7;
@@ -52,6 +55,10 @@ describe('getOverviewStats', () => {
       {
         header: 'Monitor version number',
         value: monitorVersion,
+      },
+      {
+        header: 'Last updated by',
+        value: monitor.user.name,
       },
     ]);
   });

--- a/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
+++ b/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
@@ -44,6 +44,15 @@ exports[`Monitors renders 1`] = `
           "width": "150px",
         },
         Object {
+          "field": "user",
+          "name": "Last updated by",
+          "render": [Function],
+          "sortable": true,
+          "textOnly": true,
+          "truncateText": true,
+          "width": "100px",
+        },
+        Object {
           "field": "latestAlert",
           "name": "Latest alert",
           "sortable": false,

--- a/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
+++ b/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
@@ -19,7 +19,7 @@ import moment from 'moment';
 import { DEFAULT_EMPTY_DATA } from '../../../../../utils/constants';
 import { PLUGIN_NAME } from '../../../../../../utils/constants';
 
-const renderTime = time => {
+const renderTime = (time) => {
   const momentTime = moment(time);
   if (time && momentTime.isValid()) return momentTime.format('MM/DD/YY h:mm a');
   return DEFAULT_EMPTY_DATA;
@@ -36,6 +36,15 @@ export const columns = [
     render: (name, item) => <EuiLink href={`${PLUGIN_NAME}#/monitors/${item.id}`}>{name}</EuiLink>,
   },
   {
+    field: 'user',
+    name: 'Last updated by',
+    sortable: true,
+    truncateText: true,
+    textOnly: true,
+    width: '100px',
+    render: (_, item) => item.monitor.user.name,
+  },
+  {
     field: 'latestAlert',
     name: 'Latest alert',
     sortable: false,
@@ -49,7 +58,7 @@ export const columns = [
     sortable: false,
     truncateText: false,
     width: '100px',
-    render: enabled => (enabled ? 'Enabled' : 'Disabled'),
+    render: (enabled) => (enabled ? 'Enabled' : 'Disabled'),
   },
   {
     field: 'lastNotificationTime',

--- a/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
+++ b/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
@@ -42,7 +42,8 @@ export const columns = [
     truncateText: true,
     textOnly: true,
     width: '100px',
-    render: (_, item) => item.monitor.user.name,
+    render: (_, item) =>
+      item.monitor.user && item.monitor.user.name ? item.monitor.user.name : 'N/A',
   },
   {
     field: 'latestAlert',

--- a/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
+++ b/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
@@ -42,6 +42,12 @@ export const columns = [
     truncateText: true,
     textOnly: true,
     width: '100px',
+    /* There are 3 cases:
+    1. Monitors created by older versions and never updated.
+       These monitors won’t have User details in the monitor object. `monitor.user` will be null.
+    2. Monitors are created when security plugin is disabled, these will have empty User object.
+       (`monitor.user.name`, `monitor.user.roles` are empty )
+    3. Monitors are created when security plugin is enabled, these will have an User object. */
     render: (_, item) =>
       item.monitor.user && item.monitor.user.name ? item.monitor.user.name : 'N/A',
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Show user name who created or last updated the monitor
1. In Monitor Dashboard, add a column named "Last updated by" after "Monitor name"
![Snipaste_2020-09-24_22-34-10 user dashboard](https://user-images.githubusercontent.com/62041081/94230460-d89ea500-feb6-11ea-9ba7-2239662109e4.png)

1. In Monitor Detail page, add a field named "Last updated by" in 'OverviewStat' section
![Snipaste_2020-09-24_22-34-10 user overview](https://user-images.githubusercontent.com/62041081/94230445-cfadd380-feb6-11ea-8dfc-3e7602500d65.png)'

1. If there is no `User` info for the monitor, the fields will show as `N/A`
(Thanks @skkosuri-amzn for providing the screenshots.)

![monitor list with N:A sriram](https://user-images.githubusercontent.com/62041081/94230580-22878b00-feb7-11ea-917f-ffe7f8939eed.png)

![monitor overview with N:A sriram](https://user-images.githubusercontent.com/62041081/94230585-23b8b800-feb7-11ea-812b-9dab5dc9612f.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
