### PR TITLE
Fix Email Sender name validation and add tests related to Email Destination

### DIFF
--- a/public/pages/Destinations/components/createDestinations/Email/Sender.js
+++ b/public/pages/Destinations/components/createDestinations/Email/Sender.js
@@ -62,13 +62,13 @@ const Sender = ({ sender, arrayHelpers, context, index, onDelete }) => {
           label: 'Sender name',
           helpText:
             'A unique and descriptive name that is easy to search. ' +
-            'Valid characters are upper and lowercase a-z, 0-9, _ (underscore) and - (hyphen).',
+            'Valid characters are upper and lowercase a-z, 0-9, and _ (underscore).',
           style: { padding: '10px 0px' },
           isInvalid,
           error: hasError,
         }}
         inputProps={{
-          placeholder: 'my-sender',
+          placeholder: 'my_sender',
           onChange: (e, field, form) => {
             field.onChange(e);
             onSenderChange(index, sender, arrayHelpers);

--- a/public/pages/Destinations/components/createDestinations/Email/utils/validate.js
+++ b/public/pages/Destinations/components/createDestinations/Email/utils/validate.js
@@ -18,7 +18,7 @@ import _ from 'lodash';
 export const validateSenderName = (senders) => (value) => {
   if (!value) return 'Required';
 
-  if (!/^[A-Z0-9_-]+$/i.test(value)) return 'Invalid sender name';
+  if (!/^[A-Z0-9_]+$/i.test(value)) return 'Invalid sender name';
 
   const matches = senders.filter((sender) => sender.name === value);
   if (matches.length > 1) return 'Sender name is already being used';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove hyphens as a valid sender name to match backend validation.
Add tests related to Email Destination changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
