### PR TITLE
Get alerts, destinations, and monitors using Rest APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "lodash": "^4.17.19",
     "query-string": "5.1.1",
     "react-router-dom": "4.3.1",
-    "react-vis": "^1.11.7"
+    "react-vis": "^1.11.7",
+    "ssl-root-cas": "^1.3.1"
   },
   "resolutions": {
     "fstream": "1.0.12"

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "lodash": "^4.17.19",
     "query-string": "5.1.1",
     "react-router-dom": "4.3.1",
-    "react-vis": "^1.11.7",
-    "ssl-root-cas": "^1.3.1"
+    "react-vis": "^1.11.7"
   },
   "resolutions": {
     "fstream": "1.0.12"

--- a/public/pages/Dashboard/containers/Dashboard.test.js
+++ b/public/pages/Dashboard/containers/Dashboard.test.js
@@ -1,0 +1,92 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+
+import Dashboard from './Dashboard';
+import { historyMock, httpClientMock } from '../../../../test/mocks';
+
+const location = {
+  hash: '',
+  search: '',
+  state: undefined,
+};
+
+const runAllPromises = () => new Promise(setImmediate);
+
+describe('Dashboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders', () => {
+    const resp = {
+      data: { ok: true, alerts: [], totalAlerts: 0 },
+    };
+
+    httpClientMock.get = jest.fn().mockImplementation(() => Promise.resolve(resp));
+
+    const wrapper = mount(
+      <Dashboard httpClient={httpClientMock} history={historyMock} location={location} />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  test('getAlerts', async () => {
+    const mockAlert = {
+      id: 'id',
+      version: 'version',
+      monitor_id: 'monitor_id',
+      monitor_name: 'monitor_name',
+      monitor_version: 1,
+      trigger_id: 'trigger_id',
+      trigger_name: 'trigger_name',
+      state: 'state',
+      error_message: '',
+      alert_history: [],
+      severity: '1',
+      action_execution_results: [],
+    };
+
+    const resp = {
+      data: { ok: true, alerts: [mockAlert], totalAlerts: 1 },
+    };
+
+    // Mock return in getAlerts function
+    httpClientMock.get = jest.fn().mockImplementation(() => Promise.resolve(resp));
+
+    const wrapper = mount(
+      <Dashboard httpClient={httpClientMock} history={historyMock} location={location} />
+    );
+
+    await runAllPromises();
+
+    expect(wrapper.instance().state.totalAlerts).toBe(1);
+    expect(wrapper.instance().state.alerts.length).toBe(1);
+    expect(wrapper.instance().state.alerts[0].id).toBe('id');
+    expect(wrapper.instance().state.alerts[0].version).toBe('version');
+    expect(wrapper.instance().state.alerts[0].monitor_id).toBe('monitor_id');
+    expect(wrapper.instance().state.alerts[0].monitor_name).toBe('monitor_name');
+    expect(wrapper.instance().state.alerts[0].monitor_version).toBe(1);
+    expect(wrapper.instance().state.alerts[0].trigger_id).toBe('trigger_id');
+    expect(wrapper.instance().state.alerts[0].trigger_name).toBe('trigger_name');
+    expect(wrapper.instance().state.alerts[0].severity).toBe('1');
+    expect(wrapper.instance().state.alerts[0].action_execution_results).toStrictEqual([]);
+    expect(wrapper.instance().state.alerts[0].alert_history).toStrictEqual([]);
+    expect(wrapper.instance().state.alerts[0].error_message).toBe('');
+  });
+});

--- a/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
+++ b/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
@@ -1,0 +1,1603 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dashboard renders 1`] = `
+<Dashboard
+  detectorIds={Array []}
+  history={
+    Object {
+      "action": "REPLACE",
+      "block": [MockFunction],
+      "createHref": [MockFunction],
+      "go": [MockFunction],
+      "goBack": [MockFunction],
+      "goForward": [MockFunction],
+      "length": 0,
+      "listen": [MockFunction],
+      "location": Object {
+        "hash": "",
+        "pathname": "",
+        "search": "",
+        "state": undefined,
+      },
+      "push": [MockFunction],
+      "replace": [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {
+              "hash": "",
+              "search": "alertState=ALL&from=0&search=&severityLevel=ALL&size=20&sortDirection=desc&sortField=start_time",
+              "state": undefined,
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    }
+  }
+  httpClient={[MockFunction]}
+  location={
+    Object {
+      "hash": "",
+      "search": "",
+      "state": undefined,
+    }
+  }
+  monitorIds={Array []}
+>
+  <ContentPanel
+    actions={
+      Array [
+        <EuiButton
+          onClick={[Function]}
+        >
+          Acknowledge
+        </EuiButton>,
+      ]
+    }
+    bodyStyles={
+      Object {
+        "padding": "initial",
+      }
+    }
+    title="Alerts"
+    titleSize="l"
+  >
+    <EuiPanel
+      style={
+        Object {
+          "paddingLeft": "0px",
+          "paddingRight": "0px",
+        }
+      }
+    >
+      <div
+        className="euiPanel euiPanel--paddingMedium"
+        style={
+          Object {
+            "paddingLeft": "0px",
+            "paddingRight": "0px",
+          }
+        }
+      >
+        <EuiFlexGroup
+          alignItems="center"
+          justifyContent="spaceBetween"
+          style={
+            Object {
+              "padding": "0px 10px",
+            }
+          }
+        >
+          <div
+            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            style={
+              Object {
+                "padding": "0px 10px",
+              }
+            }
+          >
+            <EuiFlexItem>
+              <div
+                className="euiFlexItem"
+              >
+                <EuiTitle
+                  size="l"
+                >
+                  <h3
+                    className="euiTitle euiTitle--large"
+                  >
+                    Alerts
+                  </h3>
+                </EuiTitle>
+              </div>
+            </EuiFlexItem>
+            <EuiFlexItem
+              grow={false}
+            >
+              <div
+                className="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <EuiFlexGroup
+                  alignItems="center"
+                  justifyContent="spaceBetween"
+                >
+                  <div
+                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  >
+                    <EuiFlexItem
+                      key="0"
+                    >
+                      <div
+                        className="euiFlexItem"
+                      >
+                        <EuiButton
+                          onClick={[Function]}
+                        >
+                          <button
+                            className="euiButton euiButton--primary"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="euiButton__content"
+                            >
+                              <span
+                                className="euiButton__text"
+                              >
+                                Acknowledge
+                              </span>
+                            </span>
+                          </button>
+                        </EuiButton>
+                      </div>
+                    </EuiFlexItem>
+                  </div>
+                </EuiFlexGroup>
+              </div>
+            </EuiFlexItem>
+          </div>
+        </EuiFlexGroup>
+        <EuiHorizontalRule
+          className=""
+          margin="xs"
+        >
+          <hr
+            className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+          />
+        </EuiHorizontalRule>
+        <div
+          style={
+            Object {
+              "padding": "initial",
+            }
+          }
+        >
+          <DashboardControls
+            activePage={0}
+            onPageChange={[Function]}
+            onSearchChange={[Function]}
+            onSeverityChange={[Function]}
+            onStateChange={[Function]}
+            pageCount={1}
+            search=""
+            severity="ALL"
+            state="ALL"
+          >
+            <EuiFlexGroup
+              style={
+                Object {
+                  "padding": "0px 5px",
+                }
+              }
+            >
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                style={
+                  Object {
+                    "padding": "0px 5px",
+                  }
+                }
+              >
+                <EuiFlexItem>
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <EuiFieldSearch
+                      compressed={false}
+                      fullWidth={true}
+                      incremental={false}
+                      isClearable={true}
+                      isLoading={false}
+                      onChange={[Function]}
+                      placeholder="Search"
+                      value=""
+                    >
+                      <EuiFormControlLayout
+                        compressed={false}
+                        fullWidth={true}
+                        icon="search"
+                        isLoading={false}
+                      >
+                        <div
+                          className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <input
+                                className="euiFieldSearch euiFieldSearch--fullWidth"
+                                onChange={[Function]}
+                                onKeyUp={[Function]}
+                                placeholder="Search"
+                                type="search"
+                                value=""
+                              />
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              icon="search"
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayoutIcons"
+                              >
+                                <EuiFormControlLayoutCustomIcon
+                                  type="search"
+                                >
+                                  <span
+                                    className="euiFormControlLayoutCustomIcon"
+                                  >
+                                    <EuiIcon
+                                      aria-hidden="true"
+                                      className="euiFormControlLayoutCustomIcon__icon"
+                                      type="search"
+                                    >
+                                      <div>
+                                        EuiIconMock
+                                      </div>
+                                    </EuiIcon>
+                                  </span>
+                                </EuiFormControlLayoutCustomIcon>
+                              </div>
+                            </EuiFormControlLayoutIcons>
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiFieldSearch>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiSelect
+                      onChange={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "text": "All severity levels",
+                            "value": "ALL",
+                          },
+                          Object {
+                            "text": "1",
+                            "value": "1",
+                          },
+                          Object {
+                            "text": "2",
+                            "value": "2",
+                          },
+                          Object {
+                            "text": "3",
+                            "value": "3",
+                          },
+                          Object {
+                            "text": "4",
+                            "value": "4",
+                          },
+                          Object {
+                            "text": "5",
+                            "value": "5",
+                          },
+                        ]
+                      }
+                      value="ALL"
+                    >
+                      <EuiFormControlLayout
+                        compressed={false}
+                        fullWidth={false}
+                        icon={
+                          Object {
+                            "side": "right",
+                            "type": "arrowDown",
+                          }
+                        }
+                        isLoading={false}
+                      >
+                        <div
+                          className="euiFormControlLayout"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <select
+                                className="euiSelect"
+                                onChange={[Function]}
+                                onMouseUp={[Function]}
+                                value="ALL"
+                              >
+                                <option
+                                  key="0"
+                                  value="ALL"
+                                >
+                                  All severity levels
+                                </option>
+                                <option
+                                  key="1"
+                                  value="1"
+                                >
+                                  1
+                                </option>
+                                <option
+                                  key="2"
+                                  value="2"
+                                >
+                                  2
+                                </option>
+                                <option
+                                  key="3"
+                                  value="3"
+                                >
+                                  3
+                                </option>
+                                <option
+                                  key="4"
+                                  value="4"
+                                >
+                                  4
+                                </option>
+                                <option
+                                  key="5"
+                                  value="5"
+                                >
+                                  5
+                                </option>
+                              </select>
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              icon={
+                                Object {
+                                  "side": "right",
+                                  "type": "arrowDown",
+                                }
+                              }
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                              >
+                                <EuiFormControlLayoutCustomIcon
+                                  type="arrowDown"
+                                >
+                                  <span
+                                    className="euiFormControlLayoutCustomIcon"
+                                  >
+                                    <EuiIcon
+                                      aria-hidden="true"
+                                      className="euiFormControlLayoutCustomIcon__icon"
+                                      type="arrowDown"
+                                    >
+                                      <div>
+                                        EuiIconMock
+                                      </div>
+                                    </EuiIcon>
+                                  </span>
+                                </EuiFormControlLayoutCustomIcon>
+                              </div>
+                            </EuiFormControlLayoutIcons>
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiSelect>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiSelect
+                      onChange={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "text": "All alerts",
+                            "value": "ALL",
+                          },
+                          Object {
+                            "text": "Active",
+                            "value": "ACTIVE",
+                          },
+                          Object {
+                            "text": "Acknowledged",
+                            "value": "ACKNOWLEDGED",
+                          },
+                          Object {
+                            "text": "Completed",
+                            "value": "COMPLETED",
+                          },
+                          Object {
+                            "text": "Error",
+                            "value": "ERROR",
+                          },
+                          Object {
+                            "text": "Deleted",
+                            "value": "DELETED",
+                          },
+                        ]
+                      }
+                      value="ALL"
+                    >
+                      <EuiFormControlLayout
+                        compressed={false}
+                        fullWidth={false}
+                        icon={
+                          Object {
+                            "side": "right",
+                            "type": "arrowDown",
+                          }
+                        }
+                        isLoading={false}
+                      >
+                        <div
+                          className="euiFormControlLayout"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <select
+                                className="euiSelect"
+                                onChange={[Function]}
+                                onMouseUp={[Function]}
+                                value="ALL"
+                              >
+                                <option
+                                  key="0"
+                                  value="ALL"
+                                >
+                                  All alerts
+                                </option>
+                                <option
+                                  key="1"
+                                  value="ACTIVE"
+                                >
+                                  Active
+                                </option>
+                                <option
+                                  key="2"
+                                  value="ACKNOWLEDGED"
+                                >
+                                  Acknowledged
+                                </option>
+                                <option
+                                  key="3"
+                                  value="COMPLETED"
+                                >
+                                  Completed
+                                </option>
+                                <option
+                                  key="4"
+                                  value="ERROR"
+                                >
+                                  Error
+                                </option>
+                                <option
+                                  key="5"
+                                  value="DELETED"
+                                >
+                                  Deleted
+                                </option>
+                              </select>
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              icon={
+                                Object {
+                                  "side": "right",
+                                  "type": "arrowDown",
+                                }
+                              }
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                              >
+                                <EuiFormControlLayoutCustomIcon
+                                  type="arrowDown"
+                                >
+                                  <span
+                                    className="euiFormControlLayoutCustomIcon"
+                                  >
+                                    <EuiIcon
+                                      aria-hidden="true"
+                                      className="euiFormControlLayoutCustomIcon__icon"
+                                      type="arrowDown"
+                                    >
+                                      <div>
+                                        EuiIconMock
+                                      </div>
+                                    </EuiIcon>
+                                  </span>
+                                </EuiFormControlLayoutCustomIcon>
+                              </div>
+                            </EuiFormControlLayoutIcons>
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiSelect>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                  style={
+                    Object {
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                    style={
+                      Object {
+                        "justifyContent": "center",
+                      }
+                    }
+                  >
+                    <EuiPagination
+                      activePage={0}
+                      onPageClick={[Function]}
+                      pageCount={1}
+                    >
+                      <div
+                        className="euiPagination"
+                        role="group"
+                      >
+                        <EuiI18n
+                          default="Previous page"
+                          token="euiPagination.previousPage"
+                        >
+                          <EuiButtonIcon
+                            aria-label="Previous page"
+                            color="text"
+                            data-test-subj="pagination-button-previous"
+                            disabled={true}
+                            iconType="arrowLeft"
+                            onClick={[Function]}
+                          >
+                            <button
+                              aria-label="Previous page"
+                              className="euiButtonIcon euiButtonIcon--text"
+                              data-test-subj="pagination-button-previous"
+                              disabled={true}
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <EuiIcon
+                                aria-hidden="true"
+                                className="euiButtonIcon__icon"
+                                size="m"
+                                type="arrowLeft"
+                              >
+                                <div>
+                                  EuiIconMock
+                                </div>
+                              </EuiIcon>
+                            </button>
+                          </EuiButtonIcon>
+                        </EuiI18n>
+                        <EuiI18n
+                          default="Page {page} of {total}"
+                          key="0"
+                          token="euiPagination.pageOfTotal"
+                          values={
+                            Object {
+                              "page": 1,
+                              "total": 1,
+                            }
+                          }
+                        >
+                          <EuiPaginationButton
+                            aria-label="Page 1 of 1"
+                            data-test-subj="pagination-button-0"
+                            hideOnMobile={true}
+                            isActive={true}
+                            onClick={[Function]}
+                          >
+                            <EuiButtonEmpty
+                              aria-label="Page 1 of 1"
+                              className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                              color="text"
+                              data-test-subj="pagination-button-0"
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              <button
+                                aria-label="Page 1 of 1"
+                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                data-test-subj="pagination-button-0"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiButtonEmpty__content"
+                                >
+                                  <span
+                                    className="euiButtonEmpty__text"
+                                  >
+                                    1
+                                  </span>
+                                </span>
+                              </button>
+                            </EuiButtonEmpty>
+                          </EuiPaginationButton>
+                        </EuiI18n>
+                        <EuiI18n
+                          default="Next page"
+                          token="euiPagination.nextPage"
+                        >
+                          <EuiButtonIcon
+                            aria-label="Next page"
+                            color="text"
+                            data-test-subj="pagination-button-next"
+                            disabled={true}
+                            iconType="arrowRight"
+                            onClick={[Function]}
+                          >
+                            <button
+                              aria-label="Next page"
+                              className="euiButtonIcon euiButtonIcon--text"
+                              data-test-subj="pagination-button-next"
+                              disabled={true}
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <EuiIcon
+                                aria-hidden="true"
+                                className="euiButtonIcon__icon"
+                                size="m"
+                                type="arrowRight"
+                              >
+                                <div>
+                                  EuiIconMock
+                                </div>
+                              </EuiIcon>
+                            </button>
+                          </EuiButtonIcon>
+                        </EuiI18n>
+                      </div>
+                    </EuiPagination>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+          </DashboardControls>
+          <EuiHorizontalRule
+            margin="xs"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+            />
+          </EuiHorizontalRule>
+          <EuiBasicTable
+            columns={
+              Array [
+                Object {
+                  "dataType": "date",
+                  "field": "start_time",
+                  "name": "Alert start time",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": false,
+                },
+                Object {
+                  "dataType": "date",
+                  "field": "end_time",
+                  "name": "Alert end time",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": false,
+                },
+                Object {
+                  "field": "monitor_name",
+                  "name": "Monitor name",
+                  "render": [Function],
+                  "sortable": true,
+                  "textOnly": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "field": "trigger_name",
+                  "name": "Trigger name",
+                  "sortable": true,
+                  "textOnly": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "field": "severity",
+                  "name": "Severity",
+                  "sortable": false,
+                  "truncateText": false,
+                },
+                Object {
+                  "field": "state",
+                  "name": "State",
+                  "render": [Function],
+                  "sortable": false,
+                  "truncateText": false,
+                },
+                Object {
+                  "dataType": "date",
+                  "field": "acknowledged_time",
+                  "name": "Time acknowledged",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": false,
+                },
+              ]
+            }
+            isSelectable={true}
+            itemId={[Function]}
+            items={Array []}
+            noItemsMessage={<DashboardEmptyPrompt />}
+            onChange={[Function]}
+            pagination={
+              Object {
+                "pageIndex": 0,
+                "pageSize": 20,
+                "pageSizeOptions": Array [
+                  5,
+                  10,
+                  20,
+                  50,
+                ],
+                "totalItemCount": 0,
+              }
+            }
+            responsive={true}
+            selection={
+              Object {
+                "onSelectionChange": [Function],
+                "selectable": [Function],
+                "selectableMessage": [Function],
+              }
+            }
+            sorting={
+              Object {
+                "sort": Object {
+                  "direction": "desc",
+                  "field": "start_time",
+                },
+              }
+            }
+            tableLayout="fixed"
+          >
+            <div
+              className="euiBasicTable"
+            >
+              <div>
+                <EuiTableHeaderMobile>
+                  <div
+                    className="euiTableHeaderMobile"
+                  >
+                    <EuiFlexGroup
+                      alignItems="baseline"
+                      justifyContent="spaceBetween"
+                      responsive={false}
+                    >
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      >
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiI18n
+                              default="Select all rows"
+                              token="euiBasicTable.selectAllRows"
+                            >
+                              <EuiCheckbox
+                                aria-label="Select all rows"
+                                checked={false}
+                                compressed={false}
+                                disabled={true}
+                                id="_selection_column-checkbox_some_make_id"
+                                indeterminate={false}
+                                label="Select all rows"
+                                onChange={[Function]}
+                              >
+                                <div
+                                  className="euiCheckbox"
+                                >
+                                  <input
+                                    aria-label="Select all rows"
+                                    checked={false}
+                                    className="euiCheckbox__input"
+                                    disabled={true}
+                                    id="_selection_column-checkbox_some_make_id"
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    className="euiCheckbox__square"
+                                  />
+                                  <label
+                                    className="euiCheckbox__label"
+                                    htmlFor="_selection_column-checkbox_some_make_id"
+                                  >
+                                    Select all rows
+                                  </label>
+                                </div>
+                              </EuiCheckbox>
+                            </EuiI18n>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiTableSortMobile
+                              items={
+                                Array [
+                                  Object {
+                                    "isSortAscending": false,
+                                    "isSorted": true,
+                                    "key": "_data_s_start_time_0",
+                                    "name": "Alert start time",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_end_time_1",
+                                    "name": "Alert end time",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_monitor_name_2",
+                                    "name": "Monitor name",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_trigger_name_3",
+                                    "name": "Trigger name",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_acknowledged_time_6",
+                                    "name": "Time acknowledged",
+                                    "onSort": [Function],
+                                  },
+                                ]
+                              }
+                            >
+                              <div
+                                className="euiTableSortMobile"
+                              >
+                                <EuiPopover
+                                  anchorPosition="downRight"
+                                  button={
+                                    <EuiButtonEmpty
+                                      flush="right"
+                                      iconSide="right"
+                                      iconType="arrowDown"
+                                      onClick={[Function]}
+                                      size="xs"
+                                    >
+                                      <EuiI18n
+                                        default="Sorting"
+                                        token="euiTableSortMobile.sorting"
+                                      />
+                                    </EuiButtonEmpty>
+                                  }
+                                  closePopover={[Function]}
+                                  display="inlineBlock"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelPaddingSize="none"
+                                >
+                                  <EuiOutsideClickDetector
+                                    isDisabled={true}
+                                    onOutsideClick={[Function]}
+                                  >
+                                    <div
+                                      className="euiPopover euiPopover--anchorDownRight"
+                                      onKeyDown={[Function]}
+                                      onMouseDown={[Function]}
+                                      onMouseUp={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchStart={[Function]}
+                                    >
+                                      <div
+                                        className="euiPopover__anchor"
+                                      >
+                                        <EuiButtonEmpty
+                                          flush="right"
+                                          iconSide="right"
+                                          iconType="arrowDown"
+                                          onClick={[Function]}
+                                          size="xs"
+                                        >
+                                          <button
+                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--iconRight euiButtonEmpty--flushRight"
+                                            onClick={[Function]}
+                                            type="button"
+                                          >
+                                            <span
+                                              className="euiButtonEmpty__content"
+                                            >
+                                              <EuiIcon
+                                                aria-hidden="true"
+                                                className="euiButtonEmpty__icon"
+                                                size="m"
+                                                type="arrowDown"
+                                              >
+                                                <div>
+                                                  EuiIconMock
+                                                </div>
+                                              </EuiIcon>
+                                              <span
+                                                className="euiButtonEmpty__text"
+                                              >
+                                                <EuiI18n
+                                                  default="Sorting"
+                                                  token="euiTableSortMobile.sorting"
+                                                >
+                                                  Sorting
+                                                </EuiI18n>
+                                              </span>
+                                            </span>
+                                          </button>
+                                        </EuiButtonEmpty>
+                                      </div>
+                                    </div>
+                                  </EuiOutsideClickDetector>
+                                </EuiPopover>
+                              </div>
+                            </EuiTableSortMobile>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </div>
+                </EuiTableHeaderMobile>
+                <EuiTable
+                  responsive={true}
+                  tableLayout="fixed"
+                >
+                  <table
+                    className="euiTable euiTable--responsive"
+                  >
+                    <EuiScreenReaderOnly>
+                      <caption
+                        className="euiScreenReaderOnly euiTableCaption"
+                      >
+                        <EuiDelayRender
+                          delay={500}
+                        />
+                      </caption>
+                    </EuiScreenReaderOnly>
+                    <EuiTableHeader>
+                      <thead>
+                        <tr>
+                          <EuiTableHeaderCellCheckbox
+                            key="_selection_column_h"
+                          >
+                            <th
+                              className="euiTableHeaderCellCheckbox"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <EuiI18n
+                                  default="Select all rows"
+                                  token="euiBasicTable.selectAllRows"
+                                >
+                                  <EuiCheckbox
+                                    aria-label="Select all rows"
+                                    checked={false}
+                                    compressed={false}
+                                    data-test-subj="checkboxSelectAll"
+                                    disabled={true}
+                                    id="_selection_column-checkbox_some_make_id"
+                                    indeterminate={false}
+                                    label={null}
+                                    onChange={[Function]}
+                                    type="inList"
+                                  >
+                                    <div
+                                      className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                    >
+                                      <input
+                                        aria-label="Select all rows"
+                                        checked={false}
+                                        className="euiCheckbox__input"
+                                        data-test-subj="checkboxSelectAll"
+                                        disabled={true}
+                                        id="_selection_column-checkbox_some_make_id"
+                                        onChange={[Function]}
+                                        type="checkbox"
+                                      />
+                                      <div
+                                        className="euiCheckbox__square"
+                                      />
+                                    </div>
+                                  </EuiCheckbox>
+                                </EuiI18n>
+                              </div>
+                            </th>
+                          </EuiTableHeaderCellCheckbox>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_start_time_0"
+                            isSortAscending={false}
+                            isSorted={true}
+                            key="_data_h_start_time_0"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="descending"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_start_time_0"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "descending",
+                                          "innerText": "Alert start time",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Alert start time; Sorted in descending order"
+                                      >
+                                        Alert start time
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiI18n
+                                    default="Sorted in {ariaSortValue} order"
+                                    token="euiTableHeaderCell.sortedAriaLabel"
+                                    values={
+                                      Object {
+                                        "ariaSortValue": "descending",
+                                      }
+                                    }
+                                  >
+                                    <EuiIcon
+                                      aria-label="Sorted in descending order"
+                                      className="euiTableSortIcon"
+                                      size="m"
+                                      type="sortDown"
+                                    >
+                                      <div>
+                                        EuiIconMock
+                                      </div>
+                                    </EuiIcon>
+                                  </EuiI18n>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_end_time_1"
+                            isSorted={false}
+                            key="_data_h_end_time_1"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_end_time_1"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "none",
+                                          "innerText": "Alert end time",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Alert end time"
+                                      >
+                                        Alert end time
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_monitor_name_2"
+                            isSorted={false}
+                            key="_data_h_monitor_name_2"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_monitor_name_2"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "none",
+                                          "innerText": "Monitor name",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Monitor name"
+                                      >
+                                        Monitor name
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_trigger_name_3"
+                            isSorted={false}
+                            key="_data_h_trigger_name_3"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_trigger_name_3"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "none",
+                                          "innerText": "Trigger name",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Trigger name"
+                                      >
+                                        Trigger name
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_severity_4"
+                            key="_data_h_severity_4"
+                          >
+                            <th
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_severity_4"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <EuiInnerText>
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="Severity"
+                                  >
+                                    Severity
+                                  </span>
+                                </EuiInnerText>
+                              </div>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_state_5"
+                            key="_data_h_state_5"
+                          >
+                            <th
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_state_5"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <EuiInnerText>
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="State"
+                                  >
+                                    State
+                                  </span>
+                                </EuiInnerText>
+                              </div>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_acknowledged_time_6"
+                            isSorted={false}
+                            key="_data_h_acknowledged_time_6"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_acknowledged_time_6"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "none",
+                                          "innerText": "Time acknowledged",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Time acknowledged"
+                                      >
+                                        Time acknowledged
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                        </tr>
+                      </thead>
+                    </EuiTableHeader>
+                    <EuiTableBody>
+                      <tbody>
+                        <EuiTableRow>
+                          <tr
+                            className="euiTableRow"
+                          >
+                            <EuiTableRowCell
+                              align="center"
+                              colSpan={8}
+                              isMobileFullWidth={true}
+                            >
+                              <td
+                                className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                                colSpan={8}
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignCenter"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                  >
+                                    <DashboardEmptyPrompt>
+                                      <EuiEmptyPrompt
+                                        actions={
+                                          <EuiButton
+                                            fill={true}
+                                            href="opendistro-alerting#/create-monitor"
+                                          >
+                                            Create monitor
+                                          </EuiButton>
+                                        }
+                                        body={
+                                          <EuiText>
+                                            <p>
+                                              There are no existing alerts. Create a monitor to add triggers and actions. Once an alarm is triggered, the state will show in this table.
+                                            </p>
+                                          </EuiText>
+                                        }
+                                        style={
+                                          Object {
+                                            "maxWidth": "45em",
+                                          }
+                                        }
+                                      >
+                                        <div
+                                          className="euiEmptyPrompt"
+                                          style={
+                                            Object {
+                                              "maxWidth": "45em",
+                                            }
+                                          }
+                                        >
+                                          <EuiTextColor
+                                            color="subdued"
+                                          >
+                                            <span
+                                              className="euiTextColor euiTextColor--subdued"
+                                            >
+                                              <EuiText>
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                >
+                                                  <EuiText>
+                                                    <div
+                                                      className="euiText euiText--medium"
+                                                    >
+                                                      <p>
+                                                        There are no existing alerts. Create a monitor to add triggers and actions. Once an alarm is triggered, the state will show in this table.
+                                                      </p>
+                                                    </div>
+                                                  </EuiText>
+                                                </div>
+                                              </EuiText>
+                                            </span>
+                                          </EuiTextColor>
+                                          <EuiSpacer
+                                            size="l"
+                                          >
+                                            <div
+                                              className="euiSpacer euiSpacer--l"
+                                            />
+                                          </EuiSpacer>
+                                          <EuiSpacer
+                                            size="s"
+                                          >
+                                            <div
+                                              className="euiSpacer euiSpacer--s"
+                                            />
+                                          </EuiSpacer>
+                                          <EuiButton
+                                            fill={true}
+                                            href="opendistro-alerting#/create-monitor"
+                                          >
+                                            <a
+                                              className="euiButton euiButton--primary euiButton--fill"
+                                              href="opendistro-alerting#/create-monitor"
+                                              rel="noreferrer"
+                                            >
+                                              <span
+                                                className="euiButton__content"
+                                              >
+                                                <span
+                                                  className="euiButton__text"
+                                                >
+                                                  Create monitor
+                                                </span>
+                                              </span>
+                                            </a>
+                                          </EuiButton>
+                                        </div>
+                                      </EuiEmptyPrompt>
+                                    </DashboardEmptyPrompt>
+                                  </span>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                          </tr>
+                        </EuiTableRow>
+                      </tbody>
+                    </EuiTableBody>
+                  </table>
+                </EuiTable>
+              </div>
+            </div>
+          </EuiBasicTable>
+        </div>
+      </div>
+    </EuiPanel>
+  </ContentPanel>
+</Dashboard>
+`;

--- a/public/pages/Destinations/containers/DestinationsList/DestinationsList.js
+++ b/public/pages/Destinations/containers/DestinationsList/DestinationsList.js
@@ -185,17 +185,21 @@ class DestinationsList extends React.Component {
         ...this.props.location,
         search: queryParms,
       });
-      const resp = await httpClient.get(`../api/alerting/destinations?${queryParms}`);
-      if (resp.data.ok) {
-        this.setState({
-          isDestinationLoading: false,
-          destinations: resp.data.destinations,
-          totalDestinations: resp.data.totalDestinations,
-        });
-      } else {
-        this.setState({
-          isDestinationLoading: false,
-        });
+      try {
+        const resp = await httpClient.get(`../api/alerting/destinations?${queryParms}`);
+        if (resp.data.ok) {
+          this.setState({
+            isDestinationLoading: false,
+            destinations: resp.data.destinations,
+            totalDestinations: resp.data.totalDestinations,
+          });
+        } else {
+          this.setState({
+            isDestinationLoading: false,
+          });
+        }
+      } catch (err) {
+        console.error('Unable to get destinations', err);
       }
     },
     500,

--- a/public/pages/Destinations/containers/DestinationsList/DestinationsList.test.js
+++ b/public/pages/Destinations/containers/DestinationsList/DestinationsList.test.js
@@ -1,0 +1,74 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+
+import DestinationsList from './DestinationsList';
+import { historyMock, httpClientMock } from '../../../../../test/mocks';
+
+const location = {
+  hash: '',
+  search: '',
+  state: undefined,
+};
+
+const runAllPromises = () => new Promise(setImmediate);
+
+describe('DestinationsList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders', () => {
+    const wrapper = mount(
+      <DestinationsList httpClient={httpClientMock} history={historyMock} location={location} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  test('getDestinations', async () => {
+    const mockDestination = {
+      id: 'id',
+      type: 'test_action',
+      name: 'destName',
+      schema_version: 1,
+      seq_no: 2,
+      primary_term: 3,
+      test_action: 'dummy',
+    };
+
+    // Mock return in getDestinations function
+    httpClientMock.get.mockResolvedValue({
+      data: { ok: true, destinations: [mockDestination], totalDestinations: 1 },
+    });
+
+    const wrapper = mount(
+      <DestinationsList httpClient={httpClientMock} history={historyMock} location={location} />
+    );
+
+    await runAllPromises();
+
+    expect(wrapper.instance().state.totalDestinations).toBe(1);
+    expect(wrapper.instance().state.destinations.length).toBe(1);
+    expect(wrapper.instance().state.destinations[0].id).toBe('id');
+    expect(wrapper.instance().state.destinations[0].type).toBe('test_action');
+    expect(wrapper.instance().state.destinations[0].name).toBe('destName');
+    expect(wrapper.instance().state.destinations[0].schema_version).toBe(1);
+    expect(wrapper.instance().state.destinations[0].seq_no).toBe(2);
+    expect(wrapper.instance().state.destinations[0].primary_term).toBe(3);
+    expect(wrapper.instance().state.destinations[0].test_action).toBe('dummy');
+  });
+});

--- a/public/pages/Destinations/containers/DestinationsList/__snapshots__/DestinationsList.test.js.snap
+++ b/public/pages/Destinations/containers/DestinationsList/__snapshots__/DestinationsList.test.js.snap
@@ -1,0 +1,1006 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DestinationsList renders 1`] = `
+<DestinationsList
+  history={
+    Object {
+      "action": "REPLACE",
+      "block": [MockFunction],
+      "createHref": [MockFunction],
+      "go": [MockFunction],
+      "goBack": [MockFunction],
+      "goForward": [MockFunction],
+      "length": 0,
+      "listen": [MockFunction],
+      "location": Object {
+        "hash": "",
+        "pathname": "",
+        "search": "",
+        "state": undefined,
+      },
+      "push": [MockFunction],
+      "replace": [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {
+              "hash": "",
+              "search": "from=0&search=&size=20&sortDirection=desc&sortField=name&type=ALL",
+              "state": undefined,
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    }
+  }
+  httpClient={[MockFunction]}
+  location={
+    Object {
+      "hash": "",
+      "search": "",
+      "state": undefined,
+    }
+  }
+>
+  <ContentPanel
+    actions={<DestinationsActions />}
+    bodyStyles={
+      Object {
+        "padding": "initial",
+      }
+    }
+    title="Destinations"
+  >
+    <EuiPanel
+      style={
+        Object {
+          "paddingLeft": "0px",
+          "paddingRight": "0px",
+        }
+      }
+    >
+      <div
+        className="euiPanel euiPanel--paddingMedium"
+        style={
+          Object {
+            "paddingLeft": "0px",
+            "paddingRight": "0px",
+          }
+        }
+      >
+        <EuiFlexGroup
+          alignItems="center"
+          justifyContent="spaceBetween"
+          style={
+            Object {
+              "padding": "0px 10px",
+            }
+          }
+        >
+          <div
+            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            style={
+              Object {
+                "padding": "0px 10px",
+              }
+            }
+          >
+            <EuiFlexItem>
+              <div
+                className="euiFlexItem"
+              >
+                <EuiTitle
+                  size="l"
+                >
+                  <h3
+                    className="euiTitle euiTitle--large"
+                  >
+                    Destinations
+                  </h3>
+                </EuiTitle>
+              </div>
+            </EuiFlexItem>
+            <EuiFlexItem
+              grow={false}
+            >
+              <div
+                className="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <EuiFlexGroup
+                  alignItems="center"
+                  justifyContent="spaceBetween"
+                >
+                  <div
+                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  >
+                    <EuiFlexItem>
+                      <div
+                        className="euiFlexItem"
+                      >
+                        <DestinationsActions>
+                          <EuiFlexGroup
+                            alignItems="center"
+                            justifyContent="spaceBetween"
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiButton
+                                    fill={true}
+                                    href="opendistro-alerting#/create-destination"
+                                  >
+                                    <a
+                                      className="euiButton euiButton--primary euiButton--fill"
+                                      href="opendistro-alerting#/create-destination"
+                                      rel="noreferrer"
+                                    >
+                                      <span
+                                        className="euiButton__content"
+                                      >
+                                        <span
+                                          className="euiButton__text"
+                                        >
+                                          Add destination
+                                        </span>
+                                      </span>
+                                    </a>
+                                  </EuiButton>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </DestinationsActions>
+                      </div>
+                    </EuiFlexItem>
+                  </div>
+                </EuiFlexGroup>
+              </div>
+            </EuiFlexItem>
+          </div>
+        </EuiFlexGroup>
+        <EuiHorizontalRule
+          className=""
+          margin="xs"
+        >
+          <hr
+            className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+          />
+        </EuiHorizontalRule>
+        <div
+          style={
+            Object {
+              "padding": "initial",
+            }
+          }
+        >
+          <DeleteConfirmation
+            isVisible={false}
+            onCancel={[Function]}
+            onConfirm={[Function]}
+          />
+          <DestinationsControls
+            activePage={0}
+            onPageClick={[Function]}
+            onSearchChange={[Function]}
+            onTypeChange={[Function]}
+            pageCount={1}
+            search=""
+            type="ALL"
+          >
+            <EuiFlexGroup
+              style={
+                Object {
+                  "padding": "0px 5px",
+                }
+              }
+            >
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                style={
+                  Object {
+                    "padding": "0px 5px",
+                  }
+                }
+              >
+                <EuiFlexItem>
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <EuiFieldSearch
+                      compressed={false}
+                      fullWidth={true}
+                      incremental={false}
+                      isClearable={true}
+                      isLoading={false}
+                      onChange={[Function]}
+                      placeholder="Search"
+                      value=""
+                    >
+                      <EuiFormControlLayout
+                        compressed={false}
+                        fullWidth={true}
+                        icon="search"
+                        isLoading={false}
+                      >
+                        <div
+                          className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <input
+                                className="euiFieldSearch euiFieldSearch--fullWidth"
+                                onChange={[Function]}
+                                onKeyUp={[Function]}
+                                placeholder="Search"
+                                type="search"
+                                value=""
+                              />
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              icon="search"
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayoutIcons"
+                              >
+                                <EuiFormControlLayoutCustomIcon
+                                  type="search"
+                                >
+                                  <span
+                                    className="euiFormControlLayoutCustomIcon"
+                                  >
+                                    <EuiIcon
+                                      aria-hidden="true"
+                                      className="euiFormControlLayoutCustomIcon__icon"
+                                      type="search"
+                                    >
+                                      <div>
+                                        EuiIconMock
+                                      </div>
+                                    </EuiIcon>
+                                  </span>
+                                </EuiFormControlLayoutCustomIcon>
+                              </div>
+                            </EuiFormControlLayoutIcons>
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiFieldSearch>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiSelect
+                      onChange={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "text": "All type",
+                            "value": "ALL",
+                          },
+                          Object {
+                            "text": "Amazon Chime",
+                            "value": "chime",
+                          },
+                          Object {
+                            "text": "Slack",
+                            "value": "slack",
+                          },
+                          Object {
+                            "text": "Custom webhook",
+                            "value": "custom_webhook",
+                          },
+                        ]
+                      }
+                      value="ALL"
+                    >
+                      <EuiFormControlLayout
+                        compressed={false}
+                        fullWidth={false}
+                        icon={
+                          Object {
+                            "side": "right",
+                            "type": "arrowDown",
+                          }
+                        }
+                        isLoading={false}
+                      >
+                        <div
+                          className="euiFormControlLayout"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <select
+                                className="euiSelect"
+                                onChange={[Function]}
+                                onMouseUp={[Function]}
+                                value="ALL"
+                              >
+                                <option
+                                  key="0"
+                                  value="ALL"
+                                >
+                                  All type
+                                </option>
+                                <option
+                                  key="1"
+                                  value="chime"
+                                >
+                                  Amazon Chime
+                                </option>
+                                <option
+                                  key="2"
+                                  value="slack"
+                                >
+                                  Slack
+                                </option>
+                                <option
+                                  key="3"
+                                  value="custom_webhook"
+                                >
+                                  Custom webhook
+                                </option>
+                              </select>
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              icon={
+                                Object {
+                                  "side": "right",
+                                  "type": "arrowDown",
+                                }
+                              }
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                              >
+                                <EuiFormControlLayoutCustomIcon
+                                  type="arrowDown"
+                                >
+                                  <span
+                                    className="euiFormControlLayoutCustomIcon"
+                                  >
+                                    <EuiIcon
+                                      aria-hidden="true"
+                                      className="euiFormControlLayoutCustomIcon__icon"
+                                      type="arrowDown"
+                                    >
+                                      <div>
+                                        EuiIconMock
+                                      </div>
+                                    </EuiIcon>
+                                  </span>
+                                </EuiFormControlLayoutCustomIcon>
+                              </div>
+                            </EuiFormControlLayoutIcons>
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiSelect>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                  style={
+                    Object {
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                    style={
+                      Object {
+                        "justifyContent": "center",
+                      }
+                    }
+                  >
+                    <EuiPagination
+                      activePage={0}
+                      onPageClick={[Function]}
+                      pageCount={1}
+                    >
+                      <div
+                        className="euiPagination"
+                        role="group"
+                      >
+                        <EuiI18n
+                          default="Previous page"
+                          token="euiPagination.previousPage"
+                        >
+                          <EuiButtonIcon
+                            aria-label="Previous page"
+                            color="text"
+                            data-test-subj="pagination-button-previous"
+                            disabled={true}
+                            iconType="arrowLeft"
+                            onClick={[Function]}
+                          >
+                            <button
+                              aria-label="Previous page"
+                              className="euiButtonIcon euiButtonIcon--text"
+                              data-test-subj="pagination-button-previous"
+                              disabled={true}
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <EuiIcon
+                                aria-hidden="true"
+                                className="euiButtonIcon__icon"
+                                size="m"
+                                type="arrowLeft"
+                              >
+                                <div>
+                                  EuiIconMock
+                                </div>
+                              </EuiIcon>
+                            </button>
+                          </EuiButtonIcon>
+                        </EuiI18n>
+                        <EuiI18n
+                          default="Page {page} of {total}"
+                          key="0"
+                          token="euiPagination.pageOfTotal"
+                          values={
+                            Object {
+                              "page": 1,
+                              "total": 1,
+                            }
+                          }
+                        >
+                          <EuiPaginationButton
+                            aria-label="Page 1 of 1"
+                            data-test-subj="pagination-button-0"
+                            hideOnMobile={true}
+                            isActive={true}
+                            onClick={[Function]}
+                          >
+                            <EuiButtonEmpty
+                              aria-label="Page 1 of 1"
+                              className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                              color="text"
+                              data-test-subj="pagination-button-0"
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              <button
+                                aria-label="Page 1 of 1"
+                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                data-test-subj="pagination-button-0"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiButtonEmpty__content"
+                                >
+                                  <span
+                                    className="euiButtonEmpty__text"
+                                  >
+                                    1
+                                  </span>
+                                </span>
+                              </button>
+                            </EuiButtonEmpty>
+                          </EuiPaginationButton>
+                        </EuiI18n>
+                        <EuiI18n
+                          default="Next page"
+                          token="euiPagination.nextPage"
+                        >
+                          <EuiButtonIcon
+                            aria-label="Next page"
+                            color="text"
+                            data-test-subj="pagination-button-next"
+                            disabled={true}
+                            iconType="arrowRight"
+                            onClick={[Function]}
+                          >
+                            <button
+                              aria-label="Next page"
+                              className="euiButtonIcon euiButtonIcon--text"
+                              data-test-subj="pagination-button-next"
+                              disabled={true}
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <EuiIcon
+                                aria-hidden="true"
+                                className="euiButtonIcon__icon"
+                                size="m"
+                                type="arrowRight"
+                              >
+                                <div>
+                                  EuiIconMock
+                                </div>
+                              </EuiIcon>
+                            </button>
+                          </EuiButtonIcon>
+                        </EuiI18n>
+                      </div>
+                    </EuiPagination>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+          </DestinationsControls>
+          <EuiHorizontalRule
+            margin="xs"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+            />
+          </EuiHorizontalRule>
+          <EuiBasicTable
+            columns={
+              Array [
+                Object {
+                  "field": "name",
+                  "name": "Destination name",
+                  "sortable": true,
+                  "textOnly": true,
+                  "truncateText": true,
+                  "width": "100px",
+                },
+                Object {
+                  "field": "type",
+                  "name": "Destination type",
+                  "render": [Function],
+                  "sortable": true,
+                  "textOnly": true,
+                  "truncateText": true,
+                  "width": "100px",
+                },
+                Object {
+                  "actions": Array [
+                    Object {
+                      "description": "Edit this destination.",
+                      "name": "Edit",
+                      "onClick": [Function],
+                    },
+                    Object {
+                      "description": "Delete this destination.",
+                      "name": "Delete",
+                      "onClick": [Function],
+                    },
+                  ],
+                  "name": "Actions",
+                  "width": "35px",
+                },
+              ]
+            }
+            hasActions={true}
+            isSelectable={true}
+            items={Array []}
+            noItemsMessage="Loading destinations..."
+            onChange={[Function]}
+            pagination={
+              Object {
+                "pageIndex": 0,
+                "pageSize": 20,
+                "pageSizeOptions": Array [
+                  5,
+                  10,
+                  20,
+                  50,
+                ],
+                "totalItemCount": 0,
+              }
+            }
+            responsive={true}
+            sorting={
+              Object {
+                "sort": Object {
+                  "direction": "desc",
+                  "field": "name",
+                },
+              }
+            }
+            tableLayout="fixed"
+          >
+            <div
+              className="euiBasicTable"
+            >
+              <div>
+                <EuiTableHeaderMobile>
+                  <div
+                    className="euiTableHeaderMobile"
+                  >
+                    <EuiFlexGroup
+                      alignItems="baseline"
+                      justifyContent="spaceBetween"
+                      responsive={false}
+                    >
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      >
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          />
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiTableSortMobile
+                              items={
+                                Array [
+                                  Object {
+                                    "isSortAscending": false,
+                                    "isSorted": true,
+                                    "key": "_data_s_name_0",
+                                    "name": "Destination name",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_type_1",
+                                    "name": "Destination type",
+                                    "onSort": [Function],
+                                  },
+                                ]
+                              }
+                            >
+                              <div
+                                className="euiTableSortMobile"
+                              >
+                                <EuiPopover
+                                  anchorPosition="downRight"
+                                  button={
+                                    <EuiButtonEmpty
+                                      flush="right"
+                                      iconSide="right"
+                                      iconType="arrowDown"
+                                      onClick={[Function]}
+                                      size="xs"
+                                    >
+                                      <EuiI18n
+                                        default="Sorting"
+                                        token="euiTableSortMobile.sorting"
+                                      />
+                                    </EuiButtonEmpty>
+                                  }
+                                  closePopover={[Function]}
+                                  display="inlineBlock"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelPaddingSize="none"
+                                >
+                                  <EuiOutsideClickDetector
+                                    isDisabled={true}
+                                    onOutsideClick={[Function]}
+                                  >
+                                    <div
+                                      className="euiPopover euiPopover--anchorDownRight"
+                                      onKeyDown={[Function]}
+                                      onMouseDown={[Function]}
+                                      onMouseUp={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchStart={[Function]}
+                                    >
+                                      <div
+                                        className="euiPopover__anchor"
+                                      >
+                                        <EuiButtonEmpty
+                                          flush="right"
+                                          iconSide="right"
+                                          iconType="arrowDown"
+                                          onClick={[Function]}
+                                          size="xs"
+                                        >
+                                          <button
+                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--iconRight euiButtonEmpty--flushRight"
+                                            onClick={[Function]}
+                                            type="button"
+                                          >
+                                            <span
+                                              className="euiButtonEmpty__content"
+                                            >
+                                              <EuiIcon
+                                                aria-hidden="true"
+                                                className="euiButtonEmpty__icon"
+                                                size="m"
+                                                type="arrowDown"
+                                              >
+                                                <div>
+                                                  EuiIconMock
+                                                </div>
+                                              </EuiIcon>
+                                              <span
+                                                className="euiButtonEmpty__text"
+                                              >
+                                                <EuiI18n
+                                                  default="Sorting"
+                                                  token="euiTableSortMobile.sorting"
+                                                >
+                                                  Sorting
+                                                </EuiI18n>
+                                              </span>
+                                            </span>
+                                          </button>
+                                        </EuiButtonEmpty>
+                                      </div>
+                                    </div>
+                                  </EuiOutsideClickDetector>
+                                </EuiPopover>
+                              </div>
+                            </EuiTableSortMobile>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </div>
+                </EuiTableHeaderMobile>
+                <EuiTable
+                  responsive={true}
+                  tableLayout="fixed"
+                >
+                  <table
+                    className="euiTable euiTable--responsive"
+                  >
+                    <EuiScreenReaderOnly>
+                      <caption
+                        className="euiScreenReaderOnly euiTableCaption"
+                      >
+                        <EuiDelayRender
+                          delay={500}
+                        />
+                      </caption>
+                    </EuiScreenReaderOnly>
+                    <EuiTableHeader>
+                      <thead>
+                        <tr>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_name_0"
+                            isSortAscending={false}
+                            isSorted={true}
+                            key="_data_h_name_0"
+                            onSort={[Function]}
+                            width="100px"
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="descending"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_name_0"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": "100px",
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "descending",
+                                          "innerText": "Destination name",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Destination name; Sorted in descending order"
+                                      >
+                                        Destination name
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiI18n
+                                    default="Sorted in {ariaSortValue} order"
+                                    token="euiTableHeaderCell.sortedAriaLabel"
+                                    values={
+                                      Object {
+                                        "ariaSortValue": "descending",
+                                      }
+                                    }
+                                  >
+                                    <EuiIcon
+                                      aria-label="Sorted in descending order"
+                                      className="euiTableSortIcon"
+                                      size="m"
+                                      type="sortDown"
+                                    >
+                                      <div>
+                                        EuiIconMock
+                                      </div>
+                                    </EuiIcon>
+                                  </EuiI18n>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_type_1"
+                            isSorted={false}
+                            key="_data_h_type_1"
+                            onSort={[Function]}
+                            width="100px"
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_type_1"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": "100px",
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "none",
+                                          "innerText": "Destination type",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Destination type"
+                                      >
+                                        Destination type
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="right"
+                            key="_actions_h_2"
+                            width="35px"
+                          >
+                            <th
+                              className="euiTableHeaderCell"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": "35px",
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                              >
+                                <EuiInnerText>
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="Actions"
+                                  >
+                                    Actions
+                                  </span>
+                                </EuiInnerText>
+                              </div>
+                            </th>
+                          </EuiTableHeaderCell>
+                        </tr>
+                      </thead>
+                    </EuiTableHeader>
+                    <EuiTableBody>
+                      <tbody>
+                        <EuiTableRow>
+                          <tr
+                            className="euiTableRow"
+                          >
+                            <EuiTableRowCell
+                              align="center"
+                              colSpan={3}
+                              isMobileFullWidth={true}
+                            >
+                              <td
+                                className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                                colSpan={3}
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignCenter"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                  >
+                                    Loading destinations...
+                                  </span>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                          </tr>
+                        </EuiTableRow>
+                      </tbody>
+                    </EuiTableBody>
+                  </table>
+                </EuiTable>
+              </div>
+            </div>
+          </EuiBasicTable>
+        </div>
+      </div>
+    </EuiPanel>
+  </ContentPanel>
+</DestinationsList>
+`;

--- a/server/clusters/alerting/alertingPlugin.js
+++ b/server/clusters/alerting/alertingPlugin.js
@@ -118,6 +118,26 @@ export default function alertingPlugin(Client, config, components) {
     method: 'POST',
   });
 
+  alerting.getDestination = ca({
+    url: {
+      fmt: `${DESTINATION_BASE_API}/<%=destinationId%>`,
+      req: {
+        destinationId: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    method: 'GET',
+  });
+
+  alerting.searchDestinations = ca({
+    url: {
+      fmt: `${DESTINATION_BASE_API}/all`,
+    },
+    method: 'GET',
+  });
+
   alerting.createDestination = ca({
     url: {
       fmt: `${DESTINATION_BASE_API}?refresh=wait_for`,

--- a/server/clusters/alerting/alertingPlugin.js
+++ b/server/clusters/alerting/alertingPlugin.js
@@ -140,7 +140,7 @@ export default function alertingPlugin(Client, config, components) {
 
   alerting.searchDestinations = ca({
     url: {
-      fmt: `${DESTINATION_BASE_API}/all`,
+      fmt: `${DESTINATION_BASE_API}`,
     },
     method: 'GET',
   });

--- a/server/clusters/alerting/alertingPlugin.js
+++ b/server/clusters/alerting/alertingPlugin.js
@@ -104,6 +104,13 @@ export default function alertingPlugin(Client, config, components) {
     method: 'POST',
   });
 
+  alerting.getAlerts = ca({
+    url: {
+      fmt: `${MONITOR_BASE_API}/alerts`,
+    },
+    method: 'GET',
+  });
+
   alerting.executeMonitor = ca({
     url: {
       fmt: `${MONITOR_BASE_API}/_execute?dryrun=<%=dryrun%>`,

--- a/server/services/AlertService.js
+++ b/server/services/AlertService.js
@@ -73,9 +73,9 @@ export default class AlertService {
     params.size = size;
     params.severityLevel = severityLevel;
     params.alertState = alertState;
-    params.monitorIds = monitorIds;
     params.searchString = search;
     if (search.trim()) params.searchString = `*${search.trim().split(' ').join('* *')}*`;
+    if (monitorIds.length > 0) params.monitorId = monitorId[0];
 
     const { callWithRequest } = this.esDriver.getCluster(CLUSTER.ALERTING);
     try {
@@ -86,7 +86,7 @@ export default class AlertService {
         const version = hit.alert_version;
         return { id, ...alert, version };
       });
-      const totalAlerts = alerts.length;
+      const totalAlerts = resp.totalAlerts;
 
       return { ok: true, alerts, totalAlerts };
     } catch (err) {

--- a/server/services/AlertService.js
+++ b/server/services/AlertService.js
@@ -25,6 +25,7 @@ export default class AlertService {
     const {
       from = 0,
       size = 20,
+      search = '',
       sortDirection = 'desc',
       sortField = 'start_time',
       severityLevel = 'ALL',
@@ -70,6 +71,11 @@ export default class AlertService {
 
     params.startIndex = from;
     params.size = size;
+    params.severityLevel = severityLevel;
+    params.alertState = alertState;
+    params.monitorIds = monitorIds;
+    params.searchString = search;
+    if (search.trim()) params.searchString = `*${search.trim().split(' ').join('* *')}*`;
 
     const { callWithRequest } = this.esDriver.getCluster(CLUSTER.ALERTING);
     try {

--- a/server/services/DestinationsService.js
+++ b/server/services/DestinationsService.js
@@ -101,30 +101,6 @@ export default class DestinationsService {
       type = 'ALL',
     } = req.query;
 
-    const filterQueries = [];
-    // Index is being used with logical doc types, filtering only destinations
-    const mustQueries = [
-      {
-        exists: {
-          field: 'destination',
-        },
-      },
-    ];
-
-    if (type !== 'ALL') {
-      filterQueries.push({ term: { 'destination.type': type } });
-    }
-
-    if (search.trim()) {
-      mustQueries.push({
-        query_string: {
-          fields: ['destination.name', 'destination.type'],
-          default_operator: 'AND',
-          query: `*${search.trim().split(' ').join('* *')}*`,
-        },
-      });
-    }
-
     var params;
     switch (sortField) {
       case 'name':

--- a/server/services/DestinationsService.js
+++ b/server/services/DestinationsService.js
@@ -70,14 +70,19 @@ export default class DestinationsService {
 
   getDestination = async (req, h) => {
     const { destinationId } = req.params;
-    const { callWithRequest } = this.esDriver.getCluster(CLUSTER.DATA);
+    const { callWithRequest } = this.esDriver.getCluster(CLUSTER.ALERTING);
     try {
-      const resp = await callWithRequest(req, 'get', {
-        index: INDEX.SCHEDULED_JOBS,
-        id: destinationId,
-      });
-      const { _source, _seq_no: ifSeqNo, _primary_term: ifPrimaryTerm, _version: version } = resp;
-      return { ok: true, destination: _source.destination, version, ifSeqNo, ifPrimaryTerm };
+      const params = {
+        destinationId,
+      };
+      const resp = await callWithRequest(req, 'alerting.getDestination', params);
+
+      const destination = resp.destinations[0];
+      const version = destination.schema_version;
+      const ifSeqNo = destination.seq_no;
+      const ifPrimaryTerm = destination.primary_term;
+
+      return { ok: true, destination, version, ifSeqNo, ifPrimaryTerm };
     } catch (err) {
       console.error('Alerting - DestinationService - getDestination:', err);
       return { ok: false, resp: err.message };
@@ -85,79 +90,26 @@ export default class DestinationsService {
   };
 
   getDestinations = async (req, h) => {
-    const {
-      from = 0,
-      size = 20,
-      search = '',
-      sortDirection = 'desc',
-      sortField = 'name',
-      type = 'ALL',
-    } = req.query;
+    const { callWithRequest } = this.esDriver.getCluster(CLUSTER.ALERTING);
 
-    const filterQueries = [];
-    // Index is being used with logical doc types, filtering only destinations
-    const mustQueries = [
-      {
-        exists: {
-          field: 'destination',
-        },
-      },
-    ];
-
-    if (type !== 'ALL') {
-      filterQueries.push({ term: { 'destination.type': type } });
-    }
-
-    if (search.trim()) {
-      mustQueries.push({
-        query_string: {
-          fields: ['destination.name', 'destination.type'],
-          default_operator: 'AND',
-          query: `*${search.trim().split(' ').join('* *')}*`,
-        },
-      });
-    }
-
-    const sortQueryMap = {
-      name: { 'destination.name.keyword': sortDirection },
-      type: { 'destination.type': sortDirection },
-    };
-
-    let sort = [];
-    const sortQuery = sortQueryMap[sortField];
-    if (sortQuery) sort = sortQuery;
-
-    const params = {
-      index: INDEX.SCHEDULED_JOBS,
-      version: true,
-      seq_no_primary_term: true,
-      body: {
-        sort,
-        size,
-        from,
-        query: {
-          bool: {
-            filter: filterQueries,
-            must: mustQueries,
-          },
-        },
-      },
-    };
-
-    const { callWithRequest } = this.esDriver.getCluster(CLUSTER.DATA);
     try {
-      const resp = await callWithRequest(req, 'search', params);
-      const totalDestinations = resp.hits.total.value;
-      const destinations = resp.hits.hits.map((hit) => {
-        const {
-          _source: destination,
-          _id: id,
-          _version: version,
-          _seq_no: ifSeqNo,
-          _primary_term: ifPrimaryTerm,
-        } = hit;
-        return { id, ...destination.destination, version, ifSeqNo, ifPrimaryTerm };
+      const p = {
+        sortString: req.query.sortField,
+        sortOrder: req.query.sortDirection,
+      };
+      const resp = await callWithRequest(req, 'alerting.searchDestinations', p);
+
+      const destinations = resp.destinations.map((hit) => {
+        const destination = hit;
+        const id = destination.id;
+        const version = destination.schema_version;
+        const ifSeqNo = destination.seq_no;
+        const ifPrimaryTerm = destination.primary_term;
+        return { id, ...destination, version, ifSeqNo, ifPrimaryTerm };
       });
+
+      const totalDestinations = destinations.length;
+
       return { ok: true, destinations, totalDestinations };
     } catch (err) {
       return { ok: false, err: err.message };

--- a/server/services/DestinationsService.js
+++ b/server/services/DestinationsService.js
@@ -92,12 +92,28 @@ export default class DestinationsService {
   getDestinations = async (req, h) => {
     const { callWithRequest } = this.esDriver.getCluster(CLUSTER.ALERTING);
 
+    const { from = 0, size = 20, sortDirection = 'desc', sortField = 'start_time' } = req.query;
+
+    var params;
+    switch (sortField) {
+      case 'name':
+        params = {
+          sortString: 'destination.name.keyword',
+          sortOrder: sortDirection,
+        };
+        break;
+      case 'type':
+        params = {
+          sortString: 'destination.type',
+          sortOrder: sortDirection,
+        };
+        break;
+    }
+    params.startIndex = from;
+    params.size = size;
+
     try {
-      const p = {
-        sortString: req.query.sortField,
-        sortOrder: req.query.sortDirection,
-      };
-      const resp = await callWithRequest(req, 'alerting.searchDestinations', p);
+      const resp = await callWithRequest(req, 'alerting.searchDestinations', params);
 
       const destinations = resp.destinations.map((hit) => {
         const destination = hit;
@@ -108,7 +124,7 @@ export default class DestinationsService {
         return { id, ...destination, version, ifSeqNo, ifPrimaryTerm };
       });
 
-      const totalDestinations = destinations.length;
+      const totalDestinations = 7;
 
       return { ok: true, destinations, totalDestinations };
     } catch (err) {

--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -59,8 +59,8 @@ export default class MonitorService {
       const ifSeqNo = _.get(getResponse, '_seq_no', null);
       const ifPrimaryTerm = _.get(getResponse, '_primary_term', null);
       if (monitor) {
-        const { callWithRequest } = this.esDriver.getCluster(CLUSTER.DATA);
-        const searchResponse = await callWithRequest(req, 'search', {
+        const { callWithRequest } = this.esDriver.getCluster(CLUSTER.ALERTING);
+        const searchResponse = await callWithRequest(req, 'alerting.getMonitors', {
           index: INDEX.ALL_ALERTS,
           body: {
             size: 0,
@@ -236,8 +236,8 @@ export default class MonitorService {
         },
       };
 
-      const { callWithRequest } = this.esDriver.getCluster(CLUSTER.DATA);
-      const esAggsResponse = await callWithRequest(req, 'search', aggsParams);
+      const { callWithRequest } = this.esDriver.getCluster(CLUSTER.ALERTING);
+      const esAggsResponse = await callWithRequest(req, 'alerting.getMonitors', aggsParams);
       const buckets = _.get(esAggsResponse, 'aggregations.uniq_monitor_ids.buckets', []).map(
         (bucket) => {
           const {

--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -34,12 +34,55 @@ export default class MonitorService {
         triggers: req.payload.triggers,
         ui_metadata: req.payload.ui_metadata,
       };
-      const fetch = require('node-fetch');
-      const createResponse = await fetch('http://localhost:9200/_opendistro/_alerting/monitors', {
+
+      const credentials = req.auth.credentials.credentials.authHeaderValue;
+      require('https').globalAgent.options.ca = require('ssl-root-cas/latest').create();
+      const https = require('https');
+      var sslRootCAs = require('ssl-root-cas/latest');
+      sslRootCAs.inject();
+
+      const options = {
         method: 'POST',
-        body: JSON.stringify(parameters),
-        headers: { 'Content-Type': 'application/json', 'User-Agent': 'Kibana' },
-      }).then((response) => response.json());
+        rejectUnauthorized: false,
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'Kibana',
+          Authorization: credentials,
+        },
+      };
+
+      function createMonitor() {
+        return new Promise((resolve, reject) => {
+          const requestCreateMonitor = https.request(
+            'https://localhost:9200/_opendistro/_alerting/monitors',
+            options,
+            (res) => {
+              let str = '';
+
+              res.on('data', (d) => {
+                str += d;
+              });
+
+              res.on('end', (d) => {
+                try {
+                  const payload = JSON.parse(str);
+                  resolve(payload);
+                } catch (e) {
+                  reject(e.message);
+                }
+              });
+
+              res.on('error', function (e) {
+                console.log('problem with request ' + e.message);
+              });
+            }
+          );
+          requestCreateMonitor.write(JSON.stringify(parameters));
+          requestCreateMonitor.end();
+        });
+      }
+      const createResponse = await createMonitor().then((response) => response);
+
       return { ok: true, resp: createResponse };
     } catch (err) {
       console.error('Alerting - MonitorService - createMonitor:', err);
@@ -50,11 +93,54 @@ export default class MonitorService {
   deleteMonitor = async (req, h) => {
     try {
       const { id } = req.params;
-      const params = { monitorId: id };
-      const fetch = require('node-fetch');
-      const resp = await fetch('http://localhost:9200/_opendistro/_alerting/monitors/' + id, {
+
+      const credentials = req.auth.credentials.credentials.authHeaderValue;
+      require('https').globalAgent.options.ca = require('ssl-root-cas/latest').create();
+      const https = require('https');
+      var sslRootCAs = require('ssl-root-cas/latest');
+      sslRootCAs.inject();
+
+      const options = {
         method: 'DELETE',
-      }).then((response) => response.json());
+        rejectUnauthorized: false,
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'Kibana',
+          Authorization: credentials,
+        },
+      };
+
+      function deleteMonitor() {
+        return new Promise((resolve, reject) => {
+          const requestDeleteMonitor = https.request(
+            'https://localhost:9200/_opendistro/_alerting/monitors/' + id,
+            options,
+            (res) => {
+              let str = '';
+
+              res.on('data', (d) => {
+                str += d;
+              });
+
+              res.on('end', (d) => {
+                try {
+                  const payload = JSON.parse(str);
+                  resolve(payload);
+                } catch (e) {
+                  reject(e.message);
+                }
+              });
+
+              res.on('error', function (e) {
+                console.log('problem with request ' + e.message);
+              });
+            }
+          );
+          requestDeleteMonitor.end();
+        });
+      }
+      await deleteMonitor().then((response) => response);
+
       return { ok: true };
     } catch (err) {
       console.error('Alerting - MonitorService - deleteMonitor:', err);
@@ -66,11 +152,48 @@ export default class MonitorService {
     try {
       const { id } = req.params;
 
-      const fetch = require('node-fetch');
-      const rep = await fetch('http://localhost:9200/_opendistro/_alerting/monitors/' + id, {
+      const credentials = req.auth.credentials.credentials.authHeaderValue;
+      require('https').globalAgent.options.ca = require('ssl-root-cas/latest').create();
+      const https = require('https');
+      var sslRootCAs = require('ssl-root-cas/latest');
+      sslRootCAs.inject();
+
+      const options = {
         method: 'GET',
-        headers: { 'User-Agent': 'Kibana' },
-      }).then((response) => response.json());
+        rejectUnauthorized: false,
+        headers: { 'User-Agent': 'Kibana', Authorization: credentials },
+      };
+
+      function getMonitor() {
+        return new Promise((resolve, reject) => {
+          const requestGetMonitor = https.get(
+            'https://localhost:9200/_opendistro/_alerting/monitors/' + id,
+            options,
+            (res) => {
+              let str = '';
+
+              res.on('data', (d) => {
+                str += d;
+              });
+
+              res.on('end', (d) => {
+                try {
+                  const payload = JSON.parse(str);
+                  resolve(payload);
+                } catch (e) {
+                  reject(e.message);
+                }
+              });
+
+              res.on('error', function (e) {
+                console.log('problem with request ' + e.message);
+              });
+            }
+          );
+          requestGetMonitor.end();
+        });
+      }
+      const rep = await getMonitor().then((response) => response);
 
       const monitor = rep.monitor;
       const version = rep.version;
@@ -104,14 +227,47 @@ export default class MonitorService {
           },
         };
 
-        const searchResponse = await fetch(
-          'http://localhost:9200/_opendistro/_alerting/monitors/_search',
-          {
-            method: 'POST',
-            body: JSON.stringify(searchParameters),
-            headers: { 'User-Agent': 'Kibana', 'Content-Type': 'application/json' },
-          }
-        ).then((response) => response.json());
+        const optionsSearch = {
+          method: 'POST',
+          rejectUnauthorized: false,
+          headers: {
+            'Content-Type': 'application/json',
+            'User-Agent': 'Kibana',
+            Authorization: credentials,
+          },
+        };
+
+        function searchMonitor() {
+          return new Promise((resolve, reject) => {
+            const requestSearchMonitor = https.request(
+              'https://localhost:9200/_opendistro/_alerting/monitors/_search',
+              optionsSearch,
+              (res) => {
+                let str = '';
+
+                res.on('data', (d) => {
+                  str += d;
+                });
+
+                res.on('end', (d) => {
+                  try {
+                    const payload = JSON.parse(str);
+                    resolve(payload);
+                  } catch (e) {
+                    reject(e.message);
+                  }
+                });
+
+                res.on('error', function (e) {
+                  console.log('problem with request ' + e.message);
+                });
+              }
+            );
+            requestSearchMonitor.write(JSON.stringify(searchParameters));
+            requestSearchMonitor.end();
+          });
+        }
+        const searchResponse = await searchMonitor().then((response) => response);
 
         const activeCount = _.get(
           searchResponse,
@@ -145,15 +301,53 @@ export default class MonitorService {
         ui_metadata: req.payload.ui_metadata,
       };
 
-      const fetch = require('node-fetch');
-      const updateResponse = await fetch(
-        'http://localhost:9200/_opendistro/_alerting/monitors/' + id,
-        {
-          method: 'PUT',
-          body: JSON.stringify(parameters),
-          headers: { 'Content-Type': 'application/json' },
-        }
-      ).then((response) => response.json());
+      const credentials = req.auth.credentials.credentials.authHeaderValue;
+      require('https').globalAgent.options.ca = require('ssl-root-cas/latest').create();
+      const https = require('https');
+      var sslRootCAs = require('ssl-root-cas/latest');
+      sslRootCAs.inject();
+
+      const options = {
+        method: 'PUT',
+        rejectUnauthorized: false,
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'Kibana',
+          Authorization: credentials,
+        },
+      };
+
+      function updateMonitor() {
+        return new Promise((resolve, reject) => {
+          const requestUpdateMonitor = https.request(
+            'https://localhost:9200/_opendistro/_alerting/monitors/' + id,
+            options,
+            (res) => {
+              let str = '';
+
+              res.on('data', (d) => {
+                str += d;
+              });
+
+              res.on('end', (d) => {
+                try {
+                  const payload = JSON.parse(str);
+                  resolve(payload);
+                } catch (e) {
+                  reject(e.message);
+                }
+              });
+
+              res.on('error', function (e) {
+                console.log('problem with request ' + e.message);
+              });
+            }
+          );
+          requestUpdateMonitor.write(JSON.stringify(parameters));
+          requestUpdateMonitor.end();
+        });
+      }
+      const updateResponse = await updateMonitor().then((response) => response);
       const { _version, _id } = updateResponse;
       return { ok: true, version: _version, id: _id };
     } catch (err) {
@@ -165,7 +359,12 @@ export default class MonitorService {
   getMonitors = async (req, h) => {
     try {
       const { from, size, search, sortDirection, sortField, state } = req.query;
-      const fetch = require('node-fetch');
+      const credentials = req.auth.credentials.credentials.authHeaderValue;
+
+      require('https').globalAgent.options.ca = require('ssl-root-cas/latest').create();
+      const https = require('https');
+      var sslRootCAs = require('ssl-root-cas/latest');
+      sslRootCAs.inject();
 
       let must = { match_all: {} };
       if (search.trim()) {
@@ -195,28 +394,59 @@ export default class MonitorService {
         monitorSortPageData.from = _.defaultTo(from, 0);
       }
 
-      const params = {
-        body: JSON.stringify({
-          seq_no_primary_term: true,
-          version: true,
-          ...monitorSortPageData,
-          query: {
-            bool: {
-              filter,
-              must,
-            },
+      const monitorDataParameter = JSON.stringify({
+        seq_no_primary_term: true,
+        version: true,
+        ...monitorSortPageData,
+        query: {
+          bool: {
+            filter,
+            must,
           },
-        }),
+        },
+      });
+
+      const options = {
+        method: 'POST',
+        rejectUnauthorized: false,
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'Kibana',
+          Authorization: credentials,
+        },
       };
 
-      const getResponse = await fetch(
-        'http://localhost:9200/_opendistro/_alerting/monitors/_search',
-        {
-          method: 'POST',
-          body: params.body,
-          headers: { 'Content-Type': 'application/json', 'User-Agent': 'Kibana' },
-        }
-      ).then((response) => response.json());
+      function getMonitorsData() {
+        return new Promise((resolve, reject) => {
+          const requestMonitorsData = https.request(
+            'https://localhost:9200/_opendistro/_alerting/monitors/_search',
+            options,
+            (res) => {
+              let str = '';
+
+              res.on('data', (d) => {
+                str += d;
+              });
+
+              res.on('end', (d) => {
+                try {
+                  const payload = JSON.parse(str);
+                  resolve(payload);
+                } catch (e) {
+                  reject(e.message);
+                }
+              });
+
+              res.on('error', function (e) {
+                console.log('problem with request ' + e.message);
+              });
+            }
+          );
+          requestMonitorsData.write(monitorDataParameter);
+          requestMonitorsData.end();
+        });
+      }
+      const getResponse = await getMonitorsData().then((response) => response);
 
       const totalMonitors = _.get(getResponse, 'hits.total.value', 0);
       const monitorKeyValueTuples = _.get(getResponse, 'hits.hits', []).map((result) => {
@@ -244,38 +474,36 @@ export default class MonitorService {
       if (aggsSorts[sortField]) {
         aggsOrderData.order = { [aggsSorts[sortField]]: sortDirection };
       }
-      const aggsParams = {
-        index: INDEX.ALL_ALERTS,
-        body: {
-          size: 0,
-          query: { terms: { monitor_id: monitorIds } },
-          aggregations: {
-            uniq_monitor_ids: {
-              terms: {
-                field: 'monitor_id',
-                ...aggsOrderData,
-                size: from + size,
-              },
-              aggregations: {
-                active: { filter: { term: { state: 'ACTIVE' } } },
-                acknowledged: { filter: { term: { state: 'ACKNOWLEDGED' } } },
-                errors: { filter: { term: { state: 'ERROR' } } },
-                ignored: {
-                  filter: {
-                    bool: {
-                      filter: { term: { state: 'COMPLETED' } },
-                      must_not: { exists: { field: 'acknowledged_time' } },
-                    },
+
+      const aggsParameters = {
+        size: 0,
+        query: { terms: { monitor_id: monitorIds } },
+        aggregations: {
+          uniq_monitor_ids: {
+            terms: {
+              field: 'monitor_id',
+              ...aggsOrderData,
+              size: from + size,
+            },
+            aggregations: {
+              active: { filter: { term: { state: 'ACTIVE' } } },
+              acknowledged: { filter: { term: { state: 'ACKNOWLEDGED' } } },
+              errors: { filter: { term: { state: 'ERROR' } } },
+              ignored: {
+                filter: {
+                  bool: {
+                    filter: { term: { state: 'COMPLETED' } },
+                    must_not: { exists: { field: 'acknowledged_time' } },
                   },
                 },
-                last_notification_time: { max: { field: 'last_notification_time' } },
-                latest_alert: {
-                  top_hits: {
-                    size: 1,
-                    sort: [{ start_time: { order: 'desc' } }],
-                    _source: {
-                      includes: ['last_notification_time', 'trigger_name'],
-                    },
+              },
+              last_notification_time: { max: { field: 'last_notification_time' } },
+              latest_alert: {
+                top_hits: {
+                  size: 1,
+                  sort: [{ start_time: { order: 'desc' } }],
+                  _source: {
+                    includes: ['last_notification_time', 'trigger_name'],
                   },
                 },
               },
@@ -284,18 +512,49 @@ export default class MonitorService {
         },
       };
 
-      const esAggsResponse = await fetch(
-        'http://localhost:9200/_opendistro/_alerting/monitors/_search',
-        {
-          method: 'POST',
-          body: JSON.stringify(aggsParams.body),
-          headers: {
-            'Content-Type': 'application/json',
-            'User-Agent': 'Kibana',
-            Index: '.opendistro-alerting-alert*',
-          },
-        }
-      ).then((response) => response.json());
+      const optionsAggs = {
+        method: 'POST',
+        rejectUnauthorized: false,
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'Kibana',
+          Authorization: credentials,
+          Index: '.opendistro-alerting-alert*',
+        },
+      };
+
+      function getAggsResponse() {
+        return new Promise((resolve, reject) => {
+          const aggsRequest = https.request(
+            'https://localhost:9200/_opendistro/_alerting/monitors/_search',
+            optionsAggs,
+            (res) => {
+              let str = '';
+
+              res.on('data', (d) => {
+                str += d;
+              });
+
+              res.on('end', (d) => {
+                try {
+                  const payload = JSON.parse(str);
+                  resolve(payload);
+                } catch (e) {
+                  reject(e.message);
+                }
+              });
+
+              res.on('error', function (e) {
+                console.log('problem with request ' + e.message);
+              });
+            }
+          );
+          aggsRequest.write(JSON.stringify(aggsParameters));
+          aggsRequest.end();
+        });
+      }
+      const esAggsResponse = await getAggsResponse().then((response) => response);
+
       const buckets = _.get(esAggsResponse, 'aggregations.uniq_monitor_ids.buckets', []).map(
         (bucket) => {
           const {
@@ -369,15 +628,54 @@ export default class MonitorService {
         body: JSON.stringify(req.payload),
       };
 
-      const fetch = require('node-fetch');
-      const result = await fetch(
-        'http://localhost:9200/_opendistro/_alerting/monitors/' + id + '/_acknowledge/alerts',
-        {
-          method: 'POST',
-          body: JSON.stringify(req.payload),
-          headers: { 'Content-Type': 'application/json' },
-        }
-      ).then((response) => response.json());
+      const credentials = req.auth.credentials.credentials.authHeaderValue;
+      require('https').globalAgent.options.ca = require('ssl-root-cas/latest').create();
+      const https = require('https');
+      var sslRootCAs = require('ssl-root-cas/latest');
+      sslRootCAs.inject();
+
+      const options = {
+        method: 'POST',
+        rejectUnauthorized: false,
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'Kibana',
+          Authorization: credentials,
+        },
+      };
+
+      function ackAlert() {
+        return new Promise((resolve, reject) => {
+          const requestAckAlert = https.request(
+            'https://localhost:9200/_opendistro/_alerting/monitors/' + id + '/_acknowledge/alerts',
+            options,
+            (res) => {
+              let str = '';
+
+              res.on('data', (d) => {
+                str += d;
+              });
+
+              res.on('end', (d) => {
+                try {
+                  const payload = JSON.parse(str);
+                  resolve(payload);
+                } catch (e) {
+                  reject(e.message);
+                }
+              });
+
+              res.on('error', function (e) {
+                console.log('problem with request ' + e.message);
+              });
+            }
+          );
+          requestAckAlert.write(JSON.stringify(req.payload));
+          requestAckAlert.end();
+        });
+      }
+      const result = await ackAlert().then((response) => response);
+
       return { ok: !result.failed.length, resp: result };
     } catch (err) {
       console.error('Alerting - MonitorService - acknowledgeAlerts:', err);
@@ -387,15 +685,53 @@ export default class MonitorService {
 
   executeMonitor = async (req, h) => {
     try {
-      const fetch = require('node-fetch');
-      const result = await fetch(
-        'http://localhost:9200/_opendistro/_alerting/monitors/_execute?dryrun=true',
-        {
-          method: 'POST',
-          body: JSON.stringify(req.payload),
-          headers: { 'Content-Type': 'application/json' },
-        }
-      ).then((response) => response.json());
+      const credentials = req.auth.credentials.credentials.authHeaderValue;
+      require('https').globalAgent.options.ca = require('ssl-root-cas/latest').create();
+      const https = require('https');
+      var sslRootCAs = require('ssl-root-cas/latest');
+      sslRootCAs.inject();
+
+      const options = {
+        method: 'POST',
+        rejectUnauthorized: false,
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'Kibana',
+          Authorization: credentials,
+        },
+      };
+
+      function executeMonitor() {
+        return new Promise((resolve, reject) => {
+          const requestExecuteMonitor = https.request(
+            'https://localhost:9200/_opendistro/_alerting/monitors/_execute?dryrun=true',
+            options,
+            (res) => {
+              let str = '';
+
+              res.on('data', (d) => {
+                str += d;
+              });
+
+              res.on('end', (d) => {
+                try {
+                  const payload = JSON.parse(str);
+                  resolve(payload);
+                } catch (e) {
+                  reject(e.message);
+                }
+              });
+
+              res.on('error', function (e) {
+                console.log('problem with request ' + e.message);
+              });
+            }
+          );
+          requestExecuteMonitor.write(JSON.stringify(req.payload));
+          requestExecuteMonitor.end();
+        });
+      }
+      const executeResponse = await executeMonitor().then((response) => response);
       return { ok: true, resp: executeResponse };
     } catch (err) {
       console.error('Alerting - MonitorService - executeMonitor:', err);


### PR DESCRIPTION
*Issue #, if available:*
#177 
*Description of changes:*
Use alerting rest APIs to retrieve alerts, destinations, and monitors instead of calling the alerting/config index directly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
