### PR TITLE
added the order for the plugin placement in kibana side menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ export default function (kibana) {
         main: `plugins/${PLUGIN_NAME}/app`,
         icon: `plugins/${PLUGIN_NAME}/images/alerting_icon.svg`,
         category: DEFAULT_APP_CATEGORIES.kibana,
+        order: 8020,
       },
 
       hacks: [`plugins/${PLUGIN_NAME}/hack`],


### PR DESCRIPTION
*[Issue](https://issues.amazon.com/issues/Kibana-1000)*

*As per the Kibana side menu requirement, Alerting should come after Query Bench:*
Order value of Visualize according to this [file](https://github.com/elastic/kibana/blob/master/src/plugins/visualize/public/plugin.ts) is 8000
So, in order to maintain Kibana plugins after Visualize order can be:
​Plugin | Order value​
-- | --
​Query Workbench | ​8010
​Alerting | ​8020
​Anomaly Detection | ​8030
​Notebooks | ​8040




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
