### PR TITLE
Modifying Alerting search detector query to bool query

### DIFF
--- a/server/services/AnomalyDetectorService.js
+++ b/server/services/AnomalyDetectorService.js
@@ -44,7 +44,7 @@ export default class DestinationsService {
 
   getDetectors = async (req, h) => {
     const searchRequest = {
-      query: { match_all: {} },
+      query: { bool: {} },
       size: MAX_DETECTOR_COUNT,
     };
     const { callWithRequest } = this.esDriver.getCluster(CLUSTER.AD_ALERTING);
@@ -54,7 +54,7 @@ export default class DestinationsService {
       });
 
       const totalDetectors = resp.hits.total.value;
-      const detectors = resp.hits.hits.map(hit => {
+      const detectors = resp.hits.hits.map((hit) => {
         const {
           _source: detector,
           _id: id,
@@ -126,7 +126,7 @@ export default class DestinationsService {
         const anomaliesResponse = await callWithRequest(req, 'alertingAD.searchResults', {
           body: requestBody,
         });
-        const transformedKeys = get(anomaliesResponse, 'hits.hits', []).map(result =>
+        const transformedKeys = get(anomaliesResponse, 'hits.hits', []).map((result) =>
           mapKeysDeep(result._source, toCamel)
         );
         return {


### PR DESCRIPTION
*Issue https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/195*

*Description of changes:*
Updating Search Detector query from `match_all` to `bool` as AD Search Detector API only supports bool queries which will filter by backend roles if enabled.
PR: https://github.com/opendistro-for-elasticsearch/anomaly-detection/pull/288

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
