### PR TITLE
Pass in isEmailAllowed for Email modals on CreateDestination page

### DIFF
--- a/public/pages/Destinations/containers/CreateDestination/EmailRecipients/EmailRecipients.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailRecipients/EmailRecipients.js
@@ -23,6 +23,8 @@ import ManageEmailGroups from '../ManageEmailGroups';
 import { validateEmailRecipients } from './utils/validate';
 import { RECIPIENT_TYPE } from './utils/constants';
 import getEmailGroups from './utils/helpers';
+import { getAllowList } from '../../../utils/helpers';
+import { DESTINATION_TYPE } from '../../../utils/constants';
 
 export default class EmailRecipients extends React.Component {
   constructor(props) {
@@ -33,13 +35,18 @@ export default class EmailRecipients extends React.Component {
       recipientOptions: [],
       isLoading: true,
       showManageEmailGroupsModal: false,
+      allowList: [],
     };
 
     this.onClickManageEmailGroups = this.onClickManageEmailGroups.bind(this);
     this.onClickCancel = this.onClickCancel.bind(this);
   }
 
-  componentDidMount() {
+  async componentDidMount() {
+    const { httpClient } = this.props;
+    const allowList = await getAllowList(httpClient);
+    this.setState({ allowList });
+
     this.loadData();
   }
 
@@ -86,6 +93,11 @@ export default class EmailRecipients extends React.Component {
       recipientOptions: emailGroupOptions,
       isLoading: false,
     });
+  };
+
+  isEmailAllowed = () => {
+    const { allowList } = this.state;
+    return allowList.includes(DESTINATION_TYPE.EMAIL);
   };
 
   render() {
@@ -143,6 +155,7 @@ export default class EmailRecipients extends React.Component {
 
         <ManageEmailGroups
           httpClient={httpClient}
+          isEmailAllowed={this.isEmailAllowed()}
           isVisible={showManageEmailGroupsModal}
           onClickCancel={this.onClickCancel}
           onClickSave={this.onClickSave}

--- a/public/pages/Destinations/containers/CreateDestination/EmailSender/EmailSender.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailSender/EmailSender.js
@@ -22,6 +22,8 @@ import { validateEmailSender } from './utils/validate';
 import { isInvalid, hasError } from '../../../../../utils/validate';
 import ManageSenders from '../ManageSenders';
 import getSenders from './utils/helpers';
+import { getAllowList } from '../../../utils/helpers';
+import { DESTINATION_TYPE } from '../../../utils/constants';
 
 export default class EmailSender extends React.Component {
   constructor(props) {
@@ -31,6 +33,7 @@ export default class EmailSender extends React.Component {
       senderOptions: [],
       loadingSenders: true,
       showManageSendersModal: false,
+      allowList: [],
     };
 
     this.onClickManageSenders = this.onClickManageSenders.bind(this);
@@ -38,7 +41,11 @@ export default class EmailSender extends React.Component {
     this.onClickSave = this.onClickSave.bind(this);
   }
 
-  componentDidMount() {
+  async componentDidMount() {
+    const { httpClient } = this.props;
+    const allowList = await getAllowList(httpClient);
+    this.setState({ allowList });
+
     this.loadSenders();
   }
 
@@ -70,6 +77,11 @@ export default class EmailSender extends React.Component {
       senderOptions,
       loadingSenders: false,
     });
+  };
+
+  isEmailAllowed = () => {
+    const { allowList } = this.state;
+    return allowList.includes(DESTINATION_TYPE.EMAIL);
   };
 
   render() {
@@ -121,6 +133,7 @@ export default class EmailSender extends React.Component {
 
         <ManageSenders
           httpClient={httpClient}
+          isEmailAllowed={this.isEmailAllowed()}
           isVisible={showManageSendersModal}
           onClickCancel={this.onClickCancel}
           onClickSave={this.onClickSave}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Create Destination page Email modals were missing an `isEmailAllowed` prop being passed in after checking the `allow_list`. Since the prop defaults to `false`, these modals were not accessible even when the Email Destination type was allowed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
