### PR TITLE
Add pre-processing to Mustache templates to reduce differences between 'Mustache.js' and 'Mustache.java'

### DIFF
--- a/public/pages/CreateTrigger/components/Action/actions/Message.js
+++ b/public/pages/CreateTrigger/components/Action/actions/Message.js
@@ -40,6 +40,7 @@ import {
   required,
 } from '../../../../../utils/validate';
 import { URL, MAX_THROTTLE_VALUE, WRONG_THROTTLE_WARNING } from '../../../../../../utils/constants';
+import { adjustMessageForPreview } from '../../../utils/AdjustActionMessage';
 
 const messageHelpText = (index, sendTestMessage) => (
   <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
@@ -73,7 +74,7 @@ const Message = ({
 }) => {
   let preview = '';
   try {
-    preview = Mustache.render(action.message_template.source, context);
+    preview = Mustache.render(adjustMessageForPreview(action.message_template.source), context);
   } catch (err) {
     preview = err.message;
     console.error('There was an error rendering mustache template', err);

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
@@ -22,6 +22,7 @@ import ContentPanel from '../../../../components/ContentPanel';
 import { FORMIK_INITIAL_ACTION_VALUES } from '../../utils/constants';
 import { DESTINATION_OPTIONS, DESTINATION_TYPE } from '../../../Destinations/utils/constants';
 import { getAllowList } from '../../../Destinations/utils/helpers';
+import { adjustMessageByAction } from '../../utils/AdjustActionMessage';
 
 const createActionContext = (context, action) => ({
   ctx: {
@@ -89,6 +90,7 @@ class ConfigureActions extends React.Component {
     const action = trigger.actions[index];
     const condition = { script: { lang: 'painless', source: 'return true' } };
     const testMonitor = { ...monitor, triggers: [{ ...trigger, actions: [action], condition }] };
+    adjustMessageByAction(action); // Pre-process the message template in the action
     try {
       const response = await httpClient.post(
         '../api/alerting/monitors/_execute?dryrun=false',

--- a/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger.js
@@ -43,6 +43,7 @@ import { triggerToFormik } from './utils/triggerToFormik';
 import { FORMIK_INITIAL_VALUES } from './utils/constants';
 import { SEARCH_TYPE } from '../../../../utils/constants';
 import { SubmitErrorHandler } from '../../../../utils/SubmitErrorHandler';
+import { adjustMessageByTrigger } from '../../utils/AdjustActionMessage';
 
 export default class CreateTrigger extends Component {
   constructor(props) {
@@ -182,6 +183,7 @@ export default class CreateTrigger extends Component {
     const monitorUiMetadata = _.get(this.props.monitor, 'ui_metadata', {});
     const trigger = formikToTrigger(values, monitorUiMetadata);
     const triggerMetadata = formikToTriggerUiMetadata(values, monitorUiMetadata);
+    adjustMessageByTrigger(trigger); // Pre-process the message template in the action
     if (this.props.edit) this.onEdit(trigger, triggerMetadata, formikBag);
     else this.onCreate(trigger, triggerMetadata, formikBag);
   };

--- a/public/pages/CreateTrigger/utils/AdjustActionMessage.js
+++ b/public/pages/CreateTrigger/utils/AdjustActionMessage.js
@@ -1,0 +1,43 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+/* Mustache templates have different implementation in different programming languages,
+ * thus the way of rendering may vary except for those are defined in the official manual.
+ * Alerting Kibana plugin uses 'Mustache.js' while Alerting plugin uses 'Mustache.java' to render templates.
+ * The below adjustment for Mustache templates aims to clean up differences between the two render engines
+ * for the user when using Alerting Kibana plugin.
+ */
+
+import _ from 'lodash';
+
+export const adjustMessageForPreview = (str) =>
+  str.replace(/({{\s*[\w\.]+\.)size(\s*}})/g, '$1length$2'); // replace "size" by "length"
+
+export const adjustMessageForBackend = (str) =>
+  str
+    .replace(/({{)\s*((#|\/|\^)\w[\w\.]*\s*}})/g, '$1$2') // remove leading spaces of sections
+    .replace(/({{\s*[\w\.]+\.)length(\s*}})/g, '$1size$2'); // replace "length" by "size"
+
+export const adjustMessageByTrigger = (trigger) => {
+  const actions = trigger.actions;
+  if (actions && actions.length > 0) {
+    return actions.map((action) => adjustMessageByAction(action));
+  }
+};
+
+export const adjustMessageByAction = (action) => {
+  const source = action.message_template.source;
+  _.set(action, 'message_template.source', adjustMessageForBackend(source));
+};

--- a/public/pages/CreateTrigger/utils/AdjustActionMessage.test.js
+++ b/public/pages/CreateTrigger/utils/AdjustActionMessage.test.js
@@ -1,0 +1,67 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import _ from 'lodash';
+import {
+  adjustMessageByTrigger,
+  adjustMessageForBackend,
+  adjustMessageForPreview,
+} from './AdjustActionMessage';
+import { FORMIK_INITIAL_VALUES } from '../containers/CreateTrigger/utils/constants';
+import { FORMIK_INITIAL_ACTION_VALUES } from './constants';
+
+describe('Mustache.js syntax', () => {
+  test('".length" can be replaced by ".size"', () => {
+    const originStrWithMatch = '{{array.length}} {{ space.length }}';
+    const resultStrWithMatch = '{{array.size}} {{ space.size }}';
+    const strWithoutMatch =
+      'length {array.length} {{length}} {{.length}} {{ .length}} {{length.}} {{.lengthOfArray}}';
+    expect(adjustMessageForBackend(originStrWithMatch)).toEqual(resultStrWithMatch);
+    expect(adjustMessageForBackend(strWithoutMatch)).toEqual(strWithoutMatch);
+  });
+
+  test('leading spaces in sections can be removed', () => {
+    const originStrWithMatch = '{{ #object}} {{  #person }} {{  ^box}} {{   /account}}';
+    const resultStrWithMatch = '{{#object}} {{#person }} {{^box}} {{/account}}';
+    const strWithoutMatch = '{{#.}} { #person} {{ $box}}';
+    expect(adjustMessageForBackend(originStrWithMatch)).toEqual(resultStrWithMatch);
+    expect(adjustMessageForBackend(strWithoutMatch)).toEqual(strWithoutMatch);
+  });
+});
+
+describe('Mustache.java syntax', () => {
+  test('".size" can be replaced by ".length"', () => {
+    const originStrWithMatch = '{{array.size}} {{ space.size }}';
+    const resultStrWithMatch = '{{array.length}} {{ space.length }}';
+    const strWithoutMatch =
+      'size {array.size} {{size}} {{.size}} {{ .size}} {{size.}} {{.sizeOfArray}}';
+    expect(adjustMessageForPreview(originStrWithMatch)).toEqual(resultStrWithMatch);
+    expect(adjustMessageForPreview(strWithoutMatch)).toEqual(strWithoutMatch);
+  });
+});
+
+describe('Message templates', () => {
+  test('can be modified by trigger', () => {
+    const testTrigger = _.cloneDeep(FORMIK_INITIAL_VALUES);
+    const testAction = _.cloneDeep(FORMIK_INITIAL_ACTION_VALUES);
+    _.set(testAction, 'message_template.source', '{{array.length}}');
+    const actions = [testAction];
+    _.set(testTrigger, 'actions', actions);
+    const expectedResult = _.cloneDeep(testTrigger);
+    _.set(expectedResult, 'actions.0.message_template.source', '{{array.size}}');
+    adjustMessageByTrigger(testTrigger);
+    expect(testTrigger).toEqual(expectedResult);
+  });
+});


### PR DESCRIPTION
*Issue #, if available:*
Mustache templates (http://mustache.github.io) has different implementation in different programming languages, and the way of rendering may vary except for those are defined in the official manual (http://mustache.github.io/mustache.5.html).

The Mustache templates in the "message preview" of an Action in Alerting Kibana plugin is rendered by JavaScript implementation (https://github.com/janl/mustache.js/).
While in the actual message, the Mustache templates is rendered in Java (https://github.com/spullara/mustache.java), which is encapsulated in Elasticsearch, and the message is sent out through Elasticsearch.

There are 2 issues that cause users confusion in using the plugin:
1. `.length` only works in `Mustache.js` to get the length of an array, but `.size` only works in `Mustache.java` to get the length of an array.
1. Sections with leading spaces, such as `{{  #object}}`, `{{  /object}}` doesn't affect the rending in `Mustache.js` but will not be rendered in `Mustache.java`

*Description of changes:*

 - Replace all `.size` in `{{ }}` by `.length` when rending the templates in the "message preview"
 - Replace all `.length` in `{{ }}` by `.size` when sending the data to backend
 - Remove all leading spaces in sections (which begins with `# or ^ or /`) when sending the data to backend
 - Defect: All the replacement will be done by force even the user don't want to.

Before:
<img width="785" alt="Snipaste_2020-10-22_17-42-29 must1" src="https://user-images.githubusercontent.com/62041081/97696582-02715b80-1a63-11eb-980c-dec3fc5258ac.png">

After:
![Snipaste_2020-10-30_03-56-14 after change mustache](https://user-images.githubusercontent.com/62041081/97697899-ea9ad700-1a64-11eb-871d-271b93be0a0c.png)
![Snipaste_2020-10-30_03-56-14 after change mustache 2](https://user-images.githubusercontent.com/62041081/97697985-0b632c80-1a65-11eb-933c-d33bbbbfcfce.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
