### PR TITLE
Remove scrolling to top when error occurs in running query when creating a monitor

### DIFF
--- a/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
@@ -341,7 +341,6 @@ class DefineMonitor extends Component {
       text: data.resp,
       toastLifeTimeMs: 20000,
     });
-    window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
   render() {


### PR DESCRIPTION
*Issue #, if available:*

When backend error occurs in running the query when creating a monitor, some errors are caused by invalid queries. In this situation, user don't what to move the focus away from the text area where the query exists.

*Description of changes:*

- Remove scrolling to top when error occurs in running query when creating a monitor

<img width="1237" alt="Snipaste_2020-10-29_20-59-00 alerting run query error" src="https://user-images.githubusercontent.com/62041081/97698247-76acfe80-1a65-11eb-8058-463507733d00.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
