### PR TITLE
Create a constant for the size of query results used for drop-down menus

### DIFF
--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
@@ -22,6 +22,7 @@ import ContentPanel from '../../../../components/ContentPanel';
 import { FORMIK_INITIAL_ACTION_VALUES } from '../../utils/constants';
 import { DESTINATION_OPTIONS, DESTINATION_TYPE } from '../../../Destinations/utils/constants';
 import { getAllowList } from '../../../Destinations/utils/helpers';
+import { MAX_QUERY_RESULT_SIZE } from '../../../../utils/constants';
 
 const createActionContext = (context, action) => ({
   ctx: {
@@ -61,7 +62,7 @@ class ConfigureActions extends React.Component {
     };
     try {
       const response = await httpClient.get('../api/alerting/destinations', {
-        query: { search: searchText, size: 200 },
+        query: { search: searchText, size: MAX_QUERY_RESULT_SIZE },
       });
       const destinations = response.destinations
         .map((destination) => ({

--- a/public/pages/Destinations/containers/CreateDestination/EmailRecipients/utils/helpers.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailRecipients/utils/helpers.js
@@ -13,10 +13,12 @@
  *   permissions and limitations under the License.
  */
 
+import { MAX_QUERY_RESULT_SIZE } from '../../../../../../utils/constants';
+
 export default async function getEmailGroups(httpClient, searchText = '') {
   try {
     const response = await httpClient.get('../api/alerting/destinations/email_groups', {
-      query: { search: searchText, size: 200 },
+      query: { search: searchText, size: MAX_QUERY_RESULT_SIZE },
     });
     if (response.ok) {
       return response.emailGroups;

--- a/public/pages/Destinations/containers/CreateDestination/EmailSender/utils/helpers.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailSender/utils/helpers.js
@@ -13,10 +13,12 @@
  *   permissions and limitations under the License.
  */
 
+import { MAX_QUERY_RESULT_SIZE } from '../../../../../../utils/constants';
+
 export default async function getSenders(httpClient, searchText = '') {
   try {
     const response = await httpClient.get('../api/alerting/destinations/email_accounts', {
-      query: { search: searchText, size: 200 },
+      query: { search: searchText, size: MAX_QUERY_RESULT_SIZE },
     });
     if (response.ok) {
       return response.emailAccounts;

--- a/public/utils/constants.js
+++ b/public/utils/constants.js
@@ -62,3 +62,5 @@ export const INPUTS_DETECTOR_ID = '0.search.query.query.bool.filter[1].term.dete
 export const MONITOR_INPUT_DETECTOR_ID = `inputs.${INPUTS_DETECTOR_ID}`;
 
 export const AD_PREVIEW_DAYS = 7;
+
+export const MAX_QUERY_RESULT_SIZE = 200;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To get the items show in the drop-down menus (`select` components), the size of the query result was set to '200' in the HTTP requests.
As the `size` is being used in more than API calls, I would like to create a constant for it.

Example of drop-down menus mentioned:
![image](https://user-images.githubusercontent.com/62041081/100139754-c86a5e00-2e44-11eb-99ca-5932955f688e.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
