### PR TITLE
Various bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please see our [documentation](https://opendistro.github.io/for-elasticsearch-do
 1. Download the Kibana source code for the [version specified in package.json](./package.json#L9) you want to set up.
 
    See the [Kibana contributing guide](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#setting-up-your-development-environment) for more instructions on setting up your development environment.
-   
+
 1. Change your node version to the version specified in `.node-version` inside the Kibana root directory.
 1. cd into the `plugins` directory of the Kibana source code directory.
 1. Check out this package from version control into the `plugins` directory.
@@ -49,7 +49,7 @@ Example output: `./build/opendistro-alerting-0.7.0.0.zip`
 
 - `yarn start`
 
-  Starts Kibana and includes this plugin. Kibana will be available on `localhost:5601`.
+  Starts Kibana on the root directory (not alerting plugin directory) and includes this plugin. Kibana will be available on `localhost:5601`.
 
 - `yarn test:jest`
 
@@ -65,7 +65,7 @@ Example output: `./build/opendistro-alerting-0.7.0.0.zip`
 
 ## License
 
-This code is licensed under the Apache 2.0 License. 
+This code is licensed under the Apache 2.0 License.
 
 ## Copyright
 

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
@@ -64,7 +64,7 @@ export function formikToAdQuery(values) {
         filter: [
           {
             range: {
-              data_end_time: {
+              execution_end_time: {
                 from: '{{period_end}}||-' + values.period.interval + 'm',
                 to: '{{period_end}}',
                 include_lower: true,

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
@@ -43,3 +43,4 @@ export const HITS_TOTAL_RESULTS_PATH = 'ctx.results[0].hits.total.value';
 export const AGGREGATION_RESULTS_PATH = 'ctx.results[0].aggregations.when.value';
 export const ANOMALY_GRADE_RESULT_PATH = 'ctx.results[0].aggregations.max_anomaly_grade.value';
 export const ANOMALY_CONFIDENCE_RESULT_PATH = 'ctx.results[0].hits.hits[0]._source.confidence';
+export const NOT_EMPTY_RESULT = 'ctx.results != null && ctx.results.length > 0';

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
@@ -20,6 +20,7 @@ import {
   TRIGGER_TYPE,
   ANOMALY_GRADE_RESULT_PATH,
   ANOMALY_CONFIDENCE_RESULT_PATH,
+  NOT_EMPTY_RESULT,
 } from './constants';
 import { SEARCH_TYPE } from '../../../../../utils/constants';
 
@@ -40,7 +41,7 @@ export function formikToTrigger(values, monitorUiMetadata = {}) {
 export function formikToAction(values) {
   const actions = values.actions;
   if (actions && actions.length > 0) {
-    return actions.map(action => {
+    return actions.map((action) => {
       if (!action.throttle_enabled) return _.omit(action, ['throttle']);
       return action;
     });
@@ -90,7 +91,7 @@ export function getADCondition(values) {
     return {
       script: {
         lang: 'painless',
-        source: `return ${ANOMALY_GRADE_RESULT_PATH} != null && ${ANOMALY_GRADE_RESULT_PATH} ${anomalyGradeOperator} ${anomalyDetector.anomalyGradeThresholdValue} && ${ANOMALY_CONFIDENCE_RESULT_PATH} ${anomalyConfidenceOperator} ${anomalyDetector.anomalyConfidenceThresholdValue}`,
+        source: `return ${NOT_EMPTY_RESULT} && ${ANOMALY_GRADE_RESULT_PATH} != null && ${ANOMALY_GRADE_RESULT_PATH} ${anomalyGradeOperator} ${anomalyDetector.anomalyGradeThresholdValue} && ${ANOMALY_CONFIDENCE_RESULT_PATH} ${anomalyConfidenceOperator} ${anomalyDetector.anomalyConfidenceThresholdValue}`,
       },
     };
   } else {

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.test.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.test.js
@@ -84,7 +84,7 @@ describe('formikToCondition', () => {
       script: {
         lang: 'painless',
         source:
-          'return ctx.results[0].aggregations.max_anomaly_grade.value != null && ctx.results[0].aggregations.max_anomaly_grade.value > 0.7 && ctx.results[0].hits.hits[0]._source.confidence > 0.7',
+          'return ctx.results != null && ctx.results.length > 0 && ctx.results[0].aggregations.max_anomaly_grade.value != null && ctx.results[0].aggregations.max_anomaly_grade.value > 0.7 && ctx.results[0].hits.hits[0]._source.confidence > 0.7',
       },
     });
   });

--- a/public/pages/CreateTrigger/containers/DefineTrigger/AnomalyDetectorTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/AnomalyDetectorTrigger.js
@@ -32,18 +32,18 @@ class AnomalyDetectorTrigger extends React.Component {
       <div style={{ padding: '0px 10px' }}>
         <AnomalyDetectorData
           detectorId={this.props.detectorId}
-          render={anomalyData => {
+          render={(anomalyData) => {
             let featureData = [];
             //Skip disabled features showing from Alerting.
             featureData = get(anomalyData, 'detector.featureAttributes', [])
-              .filter(feature => feature.featureEnabled)
+              .filter((feature) => feature.featureEnabled)
               .map((feature, index) => ({
                 featureName: feature.featureName,
                 data: anomalyData.anomalyResult.featureData[feature.featureId] || [],
               }));
             const annotations = get(anomalyData, 'anomalyResult.anomalies', [])
-              .filter(anomaly => anomaly.anomalyGrade > 0)
-              .map(anomaly => ({
+              .filter((anomaly) => anomaly.anomalyGrade > 0)
+              .map((anomaly) => ({
                 coordinates: {
                   x0: anomaly.startTime,
                   x1: anomaly.endTime,
@@ -89,14 +89,6 @@ class AnomalyDetectorTrigger extends React.Component {
                     isLoading={anomalyData.isLoading}
                     displayConfidence
                     annotationData={[{ dataValue: adValues.anomalyConfidenceThresholdValue }]}
-                  />
-                  <EuiSpacer size="m" />
-                  <FeatureChart
-                    annotations={annotations}
-                    startDateTime={anomalyData.previewStartTime}
-                    endDateTime={anomalyData.previewEndTime}
-                    featureData={featureData}
-                    isLoading={anomalyData.isLoading}
                   />
                 </React.Fragment>
               );


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/issues/211
https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/issues/210

*Description of changes:*

This PR fixes two bugs. First, we used data end time as the time field. Since we compared the current time with the data end time, we missed anomaly results when data are ingested late. This PR change to use the execute end time as the time field. Execute end time is the execution end time of an AD job run. Second, we have seen the array index out of bounds exception while evaluating the trigger condition. This PR adds array bounds check during evaluation.

This PR also removes the sample feature data graph during AD trigger creation. The graph showed multiple lines for high-cardinality detectors and was hard to read.

Testing done:
1. unit tests pass.
2. Verify that when the data end time is 10 days earlier than the execution end time, the original code cannot alert the anomaly, while the modified code can.
3. Verified AD trigger pages look as expected after removing the feature samples graph.

Before:
![ad_trigger_before](https://user-images.githubusercontent.com/5303417/100173424-5d8a4880-2e7f-11eb-8062-07cb2af7ff88.png)

After:
![ad_trigger](https://user-images.githubusercontent.com/5303417/100173442-65e28380-2e7f-11eb-8c5b-5e98a83f3d4a.png)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
