### PR TITLE
Remove icon for the ODFE category from side bar

### DIFF
--- a/public/plugin.js
+++ b/public/plugin.js
@@ -28,7 +28,6 @@ export class AlertingPlugin {
       category: {
         id: 'odfe',
         label: 'Open Distro for Elasticsearch',
-        euiIconType: 'logoKibana',
         order: 2000,
       },
       order: 4000,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

 - Remove the Kibana logo icon for the ODFE category from the side bar as it's not needed.

Before:
![image](https://user-images.githubusercontent.com/62041081/100698306-fc65e780-334c-11eb-84dd-bfcb05c04222.png)

After:
![image](https://user-images.githubusercontent.com/62041081/100698249-d3455700-334c-11eb-985f-c6e1f2dc1710.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
