### PR TITLE
Fix issue that nothing is in 'Time field' dropdown when defining monitors by visual graph

### DIFF
--- a/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
@@ -231,7 +231,7 @@ class DefineMonitor extends Component {
 
     try {
       const response = await this.props.httpClient.post('../api/alerting/_mappings', {
-        body: JSON.stringify(index),
+        body: JSON.stringify({ index }),
       });
       if (response.ok) {
         return response.resp;

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
@@ -121,7 +121,7 @@ class MonitorIndex extends React.Component {
     }
     try {
       const response = await this.props.httpClient.post('../api/alerting/_indices', {
-        body: JSON.stringify(index),
+        body: JSON.stringify({ index }),
       });
       if (response.ok) {
         const indices = response.resp.map(({ health, index, status }) => ({
@@ -151,7 +151,7 @@ class MonitorIndex extends React.Component {
 
     try {
       const response = await this.props.httpClient.post('../api/alerting/_aliases', {
-        body: JSON.stringify(alias),
+        body: JSON.stringify({ alias }),
       });
       if (response.ok) {
         const indices = response.resp.map(({ alias, index }) => ({ label: alias, index }));

--- a/server/routes/elasticsearch.js
+++ b/server/routes/elasticsearch.js
@@ -32,7 +32,9 @@ export default function (services, router) {
     {
       path: '/api/alerting/_indices',
       validate: {
-        body: schema.any(),
+        body: schema.object({
+          index: schema.string(),
+        }),
       },
     },
     elasticsearchService.getIndices
@@ -42,7 +44,9 @@ export default function (services, router) {
     {
       path: '/api/alerting/_aliases',
       validate: {
-        body: schema.any(),
+        body: schema.object({
+          alias: schema.string(),
+        }),
       },
     },
     elasticsearchService.getAliases
@@ -52,7 +56,9 @@ export default function (services, router) {
     {
       path: '/api/alerting/_mappings',
       validate: {
-        body: schema.any(),
+        body: schema.object({
+          index: schema.arrayOf(schema.string()),
+        }),
       },
     },
     elasticsearchService.getMappings

--- a/server/services/ElasticsearchService.js
+++ b/server/services/ElasticsearchService.js
@@ -82,7 +82,7 @@ export default class ElasticsearchService {
   getAliases = async (context, req, res) => {
     try {
       const { alias } = req.body;
-      const { callAsCurrentUser } = this.esDriver.asScoped(res);
+      const { callAsCurrentUser } = this.esDriver.asScoped(req);
       const aliases = await callAsCurrentUser('cat.aliases', {
         alias,
         format: 'json',
@@ -107,9 +107,9 @@ export default class ElasticsearchService {
 
   getMappings = async (context, req, res) => {
     try {
-      const params = { body: JSON.stringify(req.body) };
+      const { index } = req.body;
       const { callAsCurrentUser } = this.esDriver.asScoped(req);
-      const mappings = await callAsCurrentUser('indices.getMapping', params);
+      const mappings = await callAsCurrentUser('indices.getMapping', { index });
       return res.ok({
         body: {
           ok: true,


### PR DESCRIPTION
*Issue #, if available:*
![image](https://user-images.githubusercontent.com/62041081/101419531-0d5ead80-38a5-11eb-9e1c-89a2564e2f17.png)

*Description of changes:*
The `body` in the HTTP requests of the API calls of `get alias`, `get indices` and `get mappings` were not organized correctly during the migration to new Kibana platform (https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/pull/209)

It caused nothing shows up in the 'Time field' dropdown menu when defining monitors by visual graph.

- Organize the request body as an object to make it have got correct name-value pairs
- Make the validation of the http requests more accurate, but it's not mandatory
- Fix a typo in a handler of the http request

With the changes in the PR, the "time field" can be read and selected:
![image](https://user-images.githubusercontent.com/62041081/101420398-e6a17680-38a6-11eb-90c9-0ab2eaefac4a.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
