### PR TITLE
Remove 'JSON.stringify()' from constructing the body of API calls in request handlers 

### DIFF
--- a/server/services/DestinationsService.js
+++ b/server/services/DestinationsService.js
@@ -22,7 +22,7 @@ export default class DestinationsService {
 
   createDestination = async (context, req, res) => {
     try {
-      const params = { body: JSON.stringify(req.body) };
+      const params = { body: req.body };
       const { callAsCurrentUser } = await this.esDriver.asScoped(req);
       const createResponse = await callAsCurrentUser('alerting.createDestination', params);
       return res.ok({
@@ -47,7 +47,7 @@ export default class DestinationsService {
       const { destinationId } = req.params;
       const { ifSeqNo, ifPrimaryTerm } = req.query;
       const params = {
-        body: JSON.stringify(req.body),
+        body: req.body,
         destinationId,
         ifSeqNo,
         ifPrimaryTerm,
@@ -204,7 +204,7 @@ export default class DestinationsService {
 
   createEmailAccount = async (context, req, res) => {
     try {
-      const params = { body: JSON.stringify(req.body) };
+      const params = { body: req.body };
       const { callAsCurrentUser } = await this.esDriver.asScoped(req);
       const createResponse = await callAsCurrentUser('alerting.createEmailAccount', params);
       return res.ok({
@@ -232,7 +232,7 @@ export default class DestinationsService {
         emailAccountId: id,
         ifSeqNo,
         ifPrimaryTerm,
-        body: JSON.stringify(req.body),
+        body: req.body,
       };
       const { callAsCurrentUser } = await this.esDriver.asScoped(req);
       const updateResponse = await callAsCurrentUser('alerting.updateEmailAccount', params);
@@ -391,7 +391,7 @@ export default class DestinationsService {
 
   createEmailGroup = async (context, req, res) => {
     try {
-      const params = { body: JSON.stringify(req.body) };
+      const params = { body: req.body };
       const { callAsCurrentUser } = await this.esDriver.asScoped(req);
       const createResponse = await callAsCurrentUser('alerting.createEmailGroup', params);
       return res.ok({
@@ -419,7 +419,7 @@ export default class DestinationsService {
         emailGroupId: id,
         ifSeqNo,
         ifPrimaryTerm,
-        body: JSON.stringify(req.body),
+        body: req.body,
       };
       const { callAsCurrentUser } = await this.esDriver.asScoped(req);
       const updateResponse = await callAsCurrentUser('alerting.updateEmailGroup', params);

--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -24,7 +24,7 @@ export default class MonitorService {
 
   createMonitor = async (context, req, res) => {
     try {
-      const params = { body: JSON.stringify(req.body) };
+      const params = { body: req.body };
       const { callAsCurrentUser } = await this.esDriver.asScoped(req);
       const createResponse = await callAsCurrentUser('alerting.createMonitor', params);
       return res.ok({
@@ -137,7 +137,7 @@ export default class MonitorService {
     try {
       const { id } = req.params;
       const { ifSeqNo, ifPrimaryTerm } = req.query;
-      const params = { monitorId: id, ifSeqNo, ifPrimaryTerm, body: JSON.stringify(req.body) };
+      const params = { monitorId: id, ifSeqNo, ifPrimaryTerm, body: req.body };
       const { callAsCurrentUser } = await this.esDriver.asScoped(req);
       const updateResponse = await callAsCurrentUser('alerting.updateMonitor', params);
       const { _version, _id } = updateResponse;
@@ -192,7 +192,7 @@ export default class MonitorService {
       }
 
       const params = {
-        body: JSON.stringify({
+        body: {
           seq_no_primary_term: true,
           version: true,
           ...monitorSortPageData,
@@ -202,7 +202,7 @@ export default class MonitorService {
               must,
             },
           },
-        }),
+        },
       };
 
       const { callAsCurrentUser: alertingCallAsCurrentUser } = await this.esDriver.asScoped(req);
@@ -353,7 +353,7 @@ export default class MonitorService {
       const { id } = req.params;
       const params = {
         monitorId: id,
-        body: JSON.stringify(req.body),
+        body: req.body,
       };
       const { callAsCurrentUser } = this.esDriver.asScoped(req);
       const acknowledgeResponse = await callAsCurrentUser('alerting.acknowledgeAlerts', params);
@@ -378,7 +378,7 @@ export default class MonitorService {
     try {
       const { dryrun = 'true' } = req.query;
       const params = {
-        body: JSON.stringify(req.body),
+        body: req.body,
         dryrun,
       };
       const { callAsCurrentUser } = await this.esDriver.asScoped(req);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the new Kibana platform,  the `body` of the HTTP requests have to be wrapped in `{ body: JSON.stringify(...) }` before entering the request handlers, which was previously done in the handlers. 
The PR does the code cleanup after the migration to new Kibana platform(PR https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/pull/209/).

- remove 'JSON.stringfy()' from constructing the body of backend API calls in the request handler: 
`body: JSON.stringify(req.body)` -> `body: req.body`

Have manually tested the related actions can be performed correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
