### PR TITLE
Correct variable names of the response for getEmailAccount and getEmailGroup in the request handler

### DIFF
--- a/server/services/DestinationsService.js
+++ b/server/services/DestinationsService.js
@@ -286,7 +286,7 @@ export default class DestinationsService {
       const ifSeqNo = _.get(getResponse, '_seq_no', null);
       const ifPrimaryTerm = _.get(getResponse, '_primary_term', null);
       if (emailAccount) {
-        return resp.ok({
+        return res.ok({
           body: {
             ok: true,
             resp: emailAccount,
@@ -473,7 +473,7 @@ export default class DestinationsService {
       const ifSeqNo = _.get(getResponse, '_seq_no', null);
       const ifPrimaryTerm = _.get(getResponse, '_primary_term', null);
       if (emailGroup) {
-        return resp.ok({
+        return res.ok({
           body: {
             ok: true,
             resp: emailGroup,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is a mistake made during the migration to new Kibana platform (PR https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/pull/209)

- Correct the variable name of `res`, without which, the "sender" and "Recipients" can not displayed during editing.

![image](https://user-images.githubusercontent.com/62041081/101535674-d98b9280-394d-11eb-884e-8fadcee0667c.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
