### PR TITLE
Passing core.notifications to Email and EmailRecipients components

### DIFF
--- a/public/pages/Destinations/containers/CreateDestination/CreateDestination.js
+++ b/public/pages/Destinations/containers/CreateDestination/CreateDestination.js
@@ -167,7 +167,7 @@ class CreateDestination extends React.Component {
   };
 
   render() {
-    const { edit, httpClient, location } = this.props;
+    const { edit, httpClient, location, notifications } = this.props;
     const { initialValues } = this.state;
     return (
       <div style={{ padding: '25px 50px' }}>
@@ -232,7 +232,12 @@ class CreateDestination extends React.Component {
                   <EuiSpacer size="m" />
                   <SubHeader title={<h4>Settings</h4>} description={''} />
                   <EuiSpacer size="m" />
-                  {destinationType[values.type]({ httpClient, values, type: values.type })}
+                  {destinationType[values.type]({
+                    httpClient,
+                    values,
+                    type: values.type,
+                    notifications,
+                  })}
                 </div>
                 <EuiSpacer size="m" />
               </ContentPanel>

--- a/public/pages/Destinations/containers/CreateDestination/EmailRecipients/EmailRecipients.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailRecipients/EmailRecipients.js
@@ -101,7 +101,7 @@ export default class EmailRecipients extends React.Component {
   };
 
   render() {
-    const { httpClient, type } = this.props;
+    const { httpClient, type, notifications } = this.props;
     const { recipientOptions, isLoading, showManageEmailGroupsModal } = this.state;
     return (
       <Fragment>
@@ -159,6 +159,7 @@ export default class EmailRecipients extends React.Component {
           isVisible={showManageEmailGroupsModal}
           onClickCancel={this.onClickCancel}
           onClickSave={this.onClickSave}
+          notifications={notifications}
         />
       </Fragment>
     );
@@ -168,4 +169,5 @@ export default class EmailRecipients extends React.Component {
 EmailRecipients.propTypes = {
   httpClient: PropTypes.object.isRequired,
   type: PropTypes.string.isRequired,
+  notifications: PropTypes.object.isRequired,
 };


### PR DESCRIPTION
*Issue #, if available:*

![Snipaste_2020-12-08_13-51-34 no toast in modal email account](https://user-images.githubusercontent.com/62041081/101545863-be744f00-395c-11eb-8102-794aa74e5167.png)

![Snipaste_2020-12-08_11-57-35 manage email groups in create dest no toast](https://user-images.githubusercontent.com/62041081/101544608-d21eb600-395a-11eb-8d3c-a8068fe4a9bb.png)

*Description of changes:*

This is a mistake made during the migration to new Kibana platform (PR https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/pull/209)
Toast notifications can not be shown after clicking "Save" button in "Manage email senders" or "Manage email groups" modals when creating a Email destination.
- Passing `core.notifications` props into `Email` and `EmailRecipients` compoments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
