### PR TITLE
Fix the unit tests in v1.12.0.2

### DIFF
--- a/public/pages/Destinations/containers/CreateDestination/EmailSender/utils/helpers.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailSender/utils/helpers.js
@@ -23,7 +23,7 @@ export default async function getSenders(httpClient, searchText = '') {
     if (response.ok) {
       return response.emailAccounts;
     } else {
-      console.log('Unable to get email accounts', response.resp);
+      console.log('Unable to get email accounts', response.err);
       // TODO: 'response.ok' is 'false' when there is no alerting config index in the cluster, and notification should not be shown to new Alerting users
       // backendErrorNotification(notifications, 'get', 'email accounts', response.err);
       return [];

--- a/public/pages/Destinations/containers/CreateDestination/utils/__tests__/__snapshots__/destinationToFormik.test.js.snap
+++ b/public/pages/Destinations/containers/CreateDestination/utils/__tests__/__snapshots__/destinationToFormik.test.js.snap
@@ -28,6 +28,7 @@ Object {
       },
     ],
     "host": "https://custom.webhook",
+    "method": "PUT",
     "path": "/my_custom_path",
     "port": 80,
     "queryParams": Array [
@@ -65,6 +66,7 @@ Object {
         "value": "headerValue2",
       },
     ],
+    "method": "PUT",
     "port": 8888,
     "queryParams": Array [
       Object {
@@ -101,6 +103,7 @@ Object {
         "value": "headerValue2",
       },
     ],
+    "method": "PUT",
     "port": null,
     "queryParams": Array [
       Object {

--- a/public/pages/Destinations/containers/CreateDestination/utils/__tests__/__snapshots__/formikToDestination.test.js.snap
+++ b/public/pages/Destinations/containers/CreateDestination/utils/__tests__/__snapshots__/formikToDestination.test.js.snap
@@ -18,6 +18,7 @@ Object {
       "headerKey1": "Header Value1",
       "headerKey2": "Header Value2",
     },
+    "method": "PUT",
     "port": -1,
     "query_params": Object {
       "key1": "value1",

--- a/public/pages/Destinations/containers/CreateDestination/utils/validations.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/validations.js
@@ -27,11 +27,7 @@ export const validateDestinationName = (httpClient, destinationToEdit) => async 
     const response = await httpClient.post('../api/alerting/monitors/_search', {
       body: JSON.stringify(options),
     });
-    if (!response.ok) {
-      // TODO: 'response.ok' is 'false' when there is no alerting config index in the cluster, and notification should not be shown to new Alerting users
-      // backendErrorNotification(notifications, 'validate', 'destination name', response.resp);
-      // throw 'To create the destination, contact your administrator to obtain the following required permission for at least one of your Security role(s): cluster:admin/opendistro/alerting/monitor/search';
-    } else if (_.get(response, 'resp.hits.total.value', 0)) {
+    if (_.get(response, 'resp.hits.total.value', 0)) {
       if (!destinationToEdit) throw 'Destination name is already used';
       if (destinationToEdit && destinationToEdit.name !== value) {
         throw 'Destination name is already used';

--- a/public/pages/Destinations/containers/CreateDestination/utils/validations.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/validations.js
@@ -33,6 +33,7 @@ export const validateDestinationName = (httpClient, destinationToEdit) => async 
         throw 'Destination name is already used';
       }
     }
+    // TODO: Handle the situation that destinations with a same name can be created when user don't have the permission of 'cluster:admin/opendistro/alerting/monitor/search'
   } catch (err) {
     if (typeof err === 'string') throw err;
     throw 'There was a problem validating destination name. Please try again.';

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -189,6 +189,7 @@ export default class Monitors extends Component {
         if (!resp.ok) {
           backendErrorNotification(notifications, 'update', 'monitor', resp.resp);
         }
+        return resp;
       })
       .catch((err) => err);
   }
@@ -202,6 +203,7 @@ export default class Monitors extends Component {
         if (!resp.ok) {
           backendErrorNotification(notifications, 'delete', 'monitor', resp.resp);
         }
+        return resp;
       })
       .catch((err) => err);
   }

--- a/public/utils/validate.js
+++ b/public/utils/validate.js
@@ -65,6 +65,7 @@ export const validateMonitorName = (httpClient, monitorToEdit) => async (value) 
         throw 'Monitor name is already used';
       }
     }
+    // TODO: Handle the situation that monitors with a same name can be created when user don't have the permission of 'cluster:admin/opendistro/alerting/monitor/search'
   } catch (err) {
     if (typeof err === 'string') throw err;
     throw 'There was a problem validating monitor name. Please try again.';

--- a/public/utils/validate.js
+++ b/public/utils/validate.js
@@ -59,11 +59,7 @@ export const validateMonitorName = (httpClient, monitorToEdit) => async (value) 
     const response = await httpClient.post('../api/alerting/monitors/_search', {
       body: JSON.stringify(options),
     });
-    if (!response.ok) {
-      // TODO: 'response.ok' is 'false' when there is no alerting config index in the cluster, and notification should not be shown to new Alerting users
-      // backendErrorNotification(notifications, 'validate', 'monitor name', response);
-      // throw 'To create the monitor, contact your administrator to obtain the following required permission for at least one of your Security role(s): cluster:admin/opendistro/alerting/monitor/search';
-    } else if (_.get(response, 'resp.hits.total.value', 0)) {
+    if (_.get(response, 'resp.hits.total.value', 0)) {
       if (!monitorToEdit) throw 'Monitor name is already used';
       if (monitorToEdit && monitorToEdit.name !== value) {
         throw 'Monitor name is already used';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Some unit tests were failed in the code with tag `1.12.0.2` due to negligence.
- Add the return values of the API response back in `Monitor.js`, which are used in the unit test.
- Correct the location of the error message that used in `console.log()` in the function of getting email senders
- Remove unused codes for handling the backend error in validating names of monitor and destination, and they are causing unit test failure.
- Update the jest snapshot files which are changed due to the commit https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/commit/fa7a0b09e6f3a47b01ecc16ae64e0d6c74fd790f

Note: the mistakes mentioned in the first 3 points are introduced by PR https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/pull/219.

The only concern of the impact due to the test failure was the name validation of duplication for monitors and destinations.
I don't think it impacts the user. I manually tested creating monitors and destinations with or without the permission of  `cluster:admin/opendistro/alerting/monitor/search` in `v1.12.0.2` and compared with `v1.11.0.2`, and found nothing different.

```
Test Suites: 6 skipped, 83 passed, 83 of 89 total
Tests:       20 skipped, 383 passed, 403 total
Snapshots:   135 passed, 135 total
Time:        47.508 s, estimated 50 s
Ran all test suites.
✨  Done in 48.88s.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
