### PR TITLE
Filter out historical detectors on monitor creation page

### DIFF
--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/AnomalyDetectors.js
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/AnomalyDetectors.js
@@ -40,12 +40,14 @@ class AnomalyDetectors extends React.Component {
     try {
       const response = await httpClient.post('../api/alerting/detectors/_search');
       if (response.ok) {
-        const detectorOptions = response.detectors.map((detector) => ({
-          label: detector.name,
-          value: detector.id,
-          features: detector.featureAttributes,
-          interval: detector.detectionInterval,
-        }));
+        const detectorOptions = response.detectors
+          .filter((detector) => detector.detectionDateRange === undefined)
+          .map((detector) => ({
+            label: detector.name,
+            value: detector.id,
+            features: detector.featureAttributes,
+            interval: detector.detectionInterval,
+          }));
         this.setState({ detectorOptions });
       } else {
         // TODO: 'response.ok' is 'false' when there is no anomaly-detection config index in the cluster, and notification should not be shown to new Anomaly-Detection users


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Historical detectors are a new concept in the AD plugin that allow for creating and running the RCF and threshold models and generating anomaly results on historical/past data, rather than just real-time, streaming data. Regarding the data model, historical detectors differ by having an additional `detectionDateRange` field, which describes the specified data time range for the detector to run.

Note that historical detectors cannot be configured with monitors and generate alerts, since there is no real-time aspect of them. Because of this, historical detectors need to be filtered out on the monitor creation page. This PR addresses that.

Screenshot of the fix:
<img width="548" alt="Screen Shot 2020-12-14 at 9 53 30 AM" src="https://user-images.githubusercontent.com/62119629/102118468-95d4d500-3df4-11eb-9eb7-af5f59852bab.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
