### PR TITLE
Change the query parameters 'size' and 'search' of 'getDestinations' request to be optional

### DIFF
--- a/server/routes/destinations.js
+++ b/server/routes/destinations.js
@@ -24,8 +24,8 @@ export default function (services, router) {
       validate: {
         query: schema.object({
           from: schema.maybe(schema.number()),
-          size: schema.number(),
-          search: schema.string(),
+          size: schema.maybe(schema.number()),
+          search: schema.maybe(schema.string()),
           sortField: schema.maybe(schema.string()),
           sortDirection: schema.maybe(schema.string()),
           type: schema.maybe(schema.string()),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is a mistake made during the migration to new Kibana platform (PR https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/pull/209)

**Current behavior**: 
Destinations list fails to refresh after removing a destination.

**Reason**:
The route validation for the front-end `getDestinations` request is not correct.
No query parameters comes with the request when getting the destinations list after removing a destination.

- Change the query parameters 'size' and 'search' of 'getDestinations' request to be optional in the router.

![Snipaste_2021-01-05_22-30-13 getDestinations api when remove dest](https://user-images.githubusercontent.com/62041081/103736781-c0eeb680-4fa5-11eb-858e-3e0b78579976.png)

After the change, destinations list can be refreshed after removing a destination.

```
Test Suites: 6 skipped, 83 passed, 83 of 89 total
Tests:       20 skipped, 385 passed, 405 total
Snapshots:   135 passed, 135 total
Time:        61.738 s
Ran all test suites.
✨  Done in 62.99s.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
