### PR TITLE
Add toast notification to handle errors when updating a destination

### DIFF
--- a/public/pages/Destinations/containers/CreateDestination/CreateDestination.js
+++ b/public/pages/Destinations/containers/CreateDestination/CreateDestination.js
@@ -114,6 +114,7 @@ class CreateDestination extends React.Component {
         params: { destinationId },
       },
       history,
+      notifications,
     } = this.props;
     const { ifSeqNo, ifPrimaryTerm } = this.state;
     try {
@@ -124,6 +125,7 @@ class CreateDestination extends React.Component {
       if (resp.ok) {
         history.push(`/destinations`);
       } else {
+        backendErrorNotification(notifications, 'update', 'destination', resp.resp);
         // Handles stale Destination data.
         setSubmitting(false);
         this.getDestination(destinationId);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**Reason for the change**:

When user have both permissions of `cluster:admin/opendistro/alerting/destination/get` and `cluster:monitor/state`, user can enter the `Edit destination` page.
There is no notifications to handle the backend errors, especially the permission error, when the user attempts to click the `Update` button in the `Edit destination` page.

![image](https://user-images.githubusercontent.com/62041081/104257984-849ed880-5433-11eb-916e-c3670e716281.png)

Note:
When user only has `cluster:admin/opendistro/alerting/destination/get` permission, the `Edit` button is greyed out. It's not because the user don't have the permission to update destinations, but because the user don't have the permission to check the cluster setting, especially `opendistro.alerting.destination.allow_list`, thus no destinations is allowed for the user to edit.

![Snipaste_2021-01-11_17-19-58 edit grey](https://user-images.githubusercontent.com/62041081/104257950-6df88180-5433-11eb-8c56-06674d08868f.png)

**After the change**:
A toast notification shows up when there is an error from backend, especially the permission error, occurs when clicking the `Update` button.
![image](https://user-images.githubusercontent.com/62041081/104258189-d34c7280-5433-11eb-99be-d72f4c1f365f.png)

**Testing:**
unit test result: (Actually there is no unit tests for the toast notifications😐)
```
Test Suites: 6 skipped, 83 passed, 83 of 89 total
Tests:       20 skipped, 385 passed, 405 total
Snapshots:   135 passed, 135 total
Time:        63.306 s
Ran all test suites.
✨  Done in 64.28s.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
