### PR TITLE
Change release workflow to use new staging bucket for artifacts 

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,9 +1,12 @@
 name: Release workflow
 # This workflow is triggered on creating tags to master or an opendistro release branch
 on:
+  # push:
+  #   tags:
+  #     - 'v*'
   push:
-    tags:
-      - 'v*'
+    branches:
+      - "release-workflow-patch"
 
 jobs:
   build:
@@ -56,35 +59,39 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
       - name: Upload Artifacts to S3
         run: |
-          s3_path=s3://artifacts.opendistroforelasticsearch.amazon.com/downloads
-          aws s3 cp ${{ steps.build_zip.outputs.zip_path }} $s3_path/kibana-plugins/opendistro-alerting/
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths '/downloads/*'
-      - name: Create Github Draft Release
-        id: create_release
-        uses: actions/create-release@v1.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: true
-          prerelease: false
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: opendistro_alerting_kibana.zip
-          asset_path: ${{ steps.build_zip.outputs.zip_path }}
-          asset_content_type: application/zip
-      - name: Upload Workflow Artifacts
-        uses: actions/upload-artifact@v1
-        with:
-          name: alerting-plugin
-          path: ${{ steps.build_zip.outputs.zip_path }}
+          zip=${{ steps.build_zip.outputs.zip_path }}
+          zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+
+          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshot/kibana-plugins/alerting/"
+
+          echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
+          aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
+      # - name: Create Github Draft Release
+      #   id: create_release
+      #   uses: actions/create-release@v1.0.0
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     tag_name: ${{ github.ref }}
+      #     release_name: Release ${{ github.ref }}
+      #     draft: true
+      #     prerelease: false
+      # - name: Upload Release Asset
+      #   uses: actions/upload-release-asset@v1.0.1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_name: opendistro_alerting_kibana.zip
+      #     asset_path: ${{ steps.build_zip.outputs.zip_path }}
+      #     asset_content_type: application/zip
+      # - name: Upload Workflow Artifacts
+      #   uses: actions/upload-artifact@v1
+      #   with:
+      #     name: alerting-plugin
+      #     path: ${{ steps.build_zip.outputs.zip_path }}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -67,7 +67,7 @@ jobs:
           zip=${{ steps.build_zip.outputs.zip_path }}
           zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
 
-          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshot/kibana-plugins/alerting/"
+          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/kibana-plugins/alerting/"
 
           echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
           aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           repository: opendistro-for-elasticsearch/kibana-oss
           ref: ${{ steps.kibana_version.outputs.kibana_version }}
-          token: ${{ secrets.GITHUB_KIBANA_OSS }}
+          token: ${{ secrets.KIBANA_OSS }}
           path: kibana
       - name: Get node and yarn versions
         id: versions

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,12 +1,9 @@
 name: Release workflow
 # This workflow is triggered on creating tags to master or an opendistro release branch
 on:
-  # push:
-  #   tags:
-  #     - 'v*'
   push:
-    branches:
-      - "release-workflow-patch"
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -26,7 +23,7 @@ jobs:
         with:
           repository: opendistro-for-elasticsearch/kibana-oss
           ref: ${{ steps.kibana_version.outputs.kibana_version }}
-          token: ${{ secrets.KIBANA_OSS }}
+          token: ${{ secrets.GITHUB_KIBANA_OSS }}
           path: kibana
       - name: Get node and yarn versions
         id: versions
@@ -65,33 +62,34 @@ jobs:
       - name: Upload Artifacts to S3
         run: |
           zip=${{ steps.build_zip.outputs.zip_path }}
+          # inject build number before the suffix
           zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
 
           s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/kibana-plugins/alerting/"
 
           echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
           aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
-      # - name: Create Github Draft Release
-      #   id: create_release
-      #   uses: actions/create-release@v1.0.0
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     tag_name: ${{ github.ref }}
-      #     release_name: Release ${{ github.ref }}
-      #     draft: true
-      #     prerelease: false
-      # - name: Upload Release Asset
-      #   uses: actions/upload-release-asset@v1.0.1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_name: opendistro_alerting_kibana.zip
-      #     asset_path: ${{ steps.build_zip.outputs.zip_path }}
-      #     asset_content_type: application/zip
-      # - name: Upload Workflow Artifacts
-      #   uses: actions/upload-artifact@v1
-      #   with:
-      #     name: alerting-plugin
-      #     path: ${{ steps.build_zip.outputs.zip_path }}
+      - name: Create Github Draft Release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: false
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: opendistro_alerting_kibana.zip
+          asset_path: ${{ steps.build_zip.outputs.zip_path }}
+          asset_content_type: application/zip
+      - name: Upload Workflow Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: alerting-plugin
+          path: ${{ steps.build_zip.outputs.zip_path }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The infrastructure team is separating the production and staging locations into different AWS accounts. Plugins need to modify their workflows to publish to the new locations.

This PR changes the CD workflow to add a build number and write the zip artifact to staging.artifacts.opendistroforelasticsearch.amazon.com.

Test Results: https://github.com/gaiksaya/alerting-kibana-plugin/actions/runs/481373821

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
