### PR TITLE
Adds support to run Cypress test in an ODFE cluster with security enabled

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,6 +2,7 @@
   "defaultCommandTimeout": 10000,
   "env": {
     "elasticsearch": "localhost:9200",
-    "kibana": "localhost:5601"
+    "kibana": "localhost:5601",
+    "security_enabled": false
   }
 }

--- a/cypress/fixtures/sample_monitor_workflow.json
+++ b/cypress/fixtures/sample_monitor_workflow.json
@@ -10,10 +10,10 @@
   "inputs": [
     {
       "search": {
-        "indices": [".*"],
+        "indices": ["test*"],
         "query": {
           "query": {
-            "term": { "monitor.type": "monitor" }
+            "match_all": {}
           }
         }
       }
@@ -25,7 +25,7 @@
       "severity": "3",
       "condition": {
         "script": {
-          "source": "ctx.results[0].hits.total.value > 1",
+          "source": "ctx.results[0].hits.total.value < 1",
           "lang": "painless"
         }
       },

--- a/cypress/integration/alert_spec.js
+++ b/cypress/integration/alert_spec.js
@@ -183,6 +183,7 @@ describe('Alerts', () => {
 
   describe.only("can be in 'Deleted' state", () => {
     before(() => {
+      cy.deleteAllMonitors();
       Cypress.config('unique_number', `${Date.now()}`);
       // Modify the monitor's name to be unique
       sampleMonitorWithAlwaysTrueTrigger.name += `-${Cypress.config('unique_number')}`;

--- a/cypress/integration/alert_spec.js
+++ b/cypress/integration/alert_spec.js
@@ -94,7 +94,7 @@ describe('Alerts', () => {
   describe("can be in 'Completed' state", () => {
     before(() => {
       cy.deleteAllMonitors();
-      // Delete the indices for testing
+      // Delete the testing indices
       cy.deleteIndexByName('test*');
       Cypress.config('unique_number', `${Date.now()}`);
       // Modify the monitor name to be unique
@@ -124,12 +124,17 @@ describe('Alerts', () => {
       // Reload the page
       cy.reload();
 
+      // Type in monitor name in search box to filter out the alert
+      cy.get(`input[type="search"]`)
+        .focus()
+        .type(`${Cypress.config('unique_number')}`);
+
       // Confirm we can see the alert is in 'Completed' state
       cy.contains('Completed');
     });
 
     after(() => {
-      // Delete the indices for testing
+      // Delete the testing indices
       cy.deleteIndexByName('test*');
     });
   });
@@ -173,35 +178,14 @@ describe('Alerts', () => {
         .focus()
         .type(`${Cypress.config('unique_number')}`);
 
-      // Confirm we can see only one alert in the list
-      cy.get('tbody > tr').should(($tr) => {
-        expect($tr, '1 row').to.have.length(1);
-        expect($tr, 'item').to.contain(SAMPLE_MONITOR_TO_BE_DELETED);
-      });
-
       //Confirm there is an active alert
       cy.contains('Active');
 
-      // Click Monitors button to route to Monitors tab
-      cy.get('button').contains('Monitors').click({ force: true });
+      // Delete all existing monitors
+      cy.deleteAllMonitors();
 
-      // Confirm we can see a monitor in the list
-      cy.contains(SAMPLE_MONITOR_TO_BE_DELETED);
-
-      // Select checkbox for the existing monitor
-      cy.get('input[data-test-subj^="checkboxSelectRow-"]').click({ force: true });
-
-      // Click Actions button to open the actions menu
-      cy.contains('Actions').click({ force: true });
-
-      // Click the Delete button
-      cy.contains('Delete').click({ force: true });
-
-      // Confirm we can see an empty monitor list
-      cy.contains('There are no existing monitors');
-
-      // Click Dashboard button to route to Dashboard tab
-      cy.get('button').contains('Dashboard').click({ force: true });
+      // Reload the page
+      cy.reload();
 
       // Type in monitor name in search box to filter out the alert
       cy.get(`input[type="search"]`)

--- a/cypress/integration/alert_spec.js
+++ b/cypress/integration/alert_spec.js
@@ -181,7 +181,7 @@ describe('Alerts', () => {
     });
   });
 
-  describe.only("can be in 'Deleted' state", () => {
+  describe("can be in 'Deleted' state", () => {
     before(() => {
       cy.deleteAllMonitors();
       Cypress.config('unique_number', `${Date.now()}`);

--- a/cypress/integration/destination_spec.js
+++ b/cypress/integration/destination_spec.js
@@ -77,6 +77,7 @@ describe('Destinations', () => {
       cy.get('button').contains('Edit').click({ force: true });
 
       // Wait for input to load and then type in the destination name
+      // should() is used to wait for input loading before clearing
       cy.get('input[name="name"]')
         .should('have.value', SAMPLE_DESTINATION)
         .clear()

--- a/cypress/integration/destination_spec.js
+++ b/cypress/integration/destination_spec.js
@@ -14,7 +14,7 @@
  */
 
 import { PLUGIN_NAME } from '../support/constants';
-import sampleDestination from '../fixtures/sample_destination_custom_webhook.json';
+import sampleDestination from '../fixtures/sample_destination_custom_webhook';
 import sampleDestinationChime from '../fixtures/sample_destination_chime';
 
 const SAMPLE_DESTINATION = 'sample_destination';
@@ -36,7 +36,7 @@ describe('Destinations', () => {
 
   describe('can be created', () => {
     before(() => {
-      cy.deleteAllIndices();
+      cy.deleteAllDestinations();
     });
 
     it('with a custom webhook', () => {
@@ -65,7 +65,7 @@ describe('Destinations', () => {
 
   describe('can be updated', () => {
     before(() => {
-      cy.deleteAllIndices();
+      cy.deleteAllDestinations();
       cy.createDestination(sampleDestination);
     });
 
@@ -77,7 +77,10 @@ describe('Destinations', () => {
       cy.get('button').contains('Edit').click({ force: true });
 
       // Wait for input to load and then type in the destination name
-      cy.get('input[name="name"]').focus().clear().type(UPDATED_DESTINATION, { force: true });
+      cy.get('input[name="name"]')
+        .should('have.value', SAMPLE_DESTINATION)
+        .clear()
+        .type(UPDATED_DESTINATION, { force: true });
 
       // Click the create button
       cy.get('button').contains('Update').click({ force: true });
@@ -89,7 +92,7 @@ describe('Destinations', () => {
 
   describe('can be deleted', () => {
     before(() => {
-      cy.deleteAllIndices();
+      cy.deleteAllDestinations();
       cy.createDestination(sampleDestination);
     });
 
@@ -110,7 +113,7 @@ describe('Destinations', () => {
 
   describe('can be searched', () => {
     before(() => {
-      cy.deleteAllIndices();
+      cy.deleteAllDestinations();
       // Create 21 destinations so that a monitor will not appear in the first page
       for (let i = 0; i < 20; i++) {
         cy.createDestination(sampleDestination);
@@ -134,5 +137,10 @@ describe('Destinations', () => {
         expect($tr, 'item').to.contain(SAMPLE_DESTINATION_WITH_ANOTHER_NAME);
       });
     });
+  });
+
+  after(() => {
+    // Delete all existing destinations
+    cy.deleteAllDestinations();
   });
 });

--- a/cypress/integration/monitor_spec.js
+++ b/cypress/integration/monitor_spec.js
@@ -18,13 +18,11 @@ import sampleMonitor from '../fixtures/sample_monitor';
 import sampleMonitorWithAlwaysTrueTrigger from '../fixtures/sample_monitor_with_always_true_trigger';
 import sampleDestination from '../fixtures/sample_destination_custom_webhook.json';
 
-const SAMPLE_MONITOR = `sample_monitor-${Cypress.config('unique_number')}`;
-const UPDATED_MONITOR = `updated_monitor-${Cypress.config('unique_number')}`;
-const SAMPLE_MONITOR_WITH_ANOTHER_NAME = `sample_monitor_with_always_true_trigger-${Cypress.config(
-  'unique_number'
-)}`;
-const SAMPLE_TRIGGER = `sample_trigger-${Cypress.config('unique_number')}`;
-const SAMPLE_ACTION = `sample_action-${Cypress.config('unique_number')}`;
+const SAMPLE_MONITOR = 'sample_monitor';
+const UPDATED_MONITOR = 'updated_monitor';
+const SAMPLE_MONITOR_WITH_ANOTHER_NAME = 'sample_monitor_with_always_true_trigger';
+const SAMPLE_TRIGGER = 'sample_trigger';
+const SAMPLE_ACTION = 'sample_action';
 
 describe('Monitors', () => {
   beforeEach(() => {
@@ -38,12 +36,15 @@ describe('Monitors', () => {
     cy.contains('Create monitor', { timeout: 20000 });
   });
 
-  describe.only('can be created', () => {
+  describe('can be created', () => {
     before(() => {
-      cy.deleteAllMonitors2();
+      cy.deleteAllMonitors();
     });
 
     it('defining by extraction query', () => {
+      // Confirm we loaded empty monitor list
+      cy.contains('There are no existing monitors');
+
       // Route us to create monitor page
       cy.contains('Create monitor').click({ force: true });
 
@@ -68,16 +69,11 @@ describe('Monitors', () => {
       // Confirm we can see the created monitor in the list
       cy.contains(SAMPLE_MONITOR);
     });
-
-    after(() => {
-      cy.deleteMonitorByName(SAMPLE_MONITOR);
-    });
   });
 
   describe('can be updated', () => {
     before(() => {
-      cy.deleteAllMonitors2();
-      sampleMonitor.name = SAMPLE_MONITOR; // Modify the monitor's name to be unique
+      cy.deleteAllMonitors();
       cy.createMonitor(sampleMonitor);
     });
 
@@ -92,7 +88,10 @@ describe('Monitors', () => {
       cy.contains('Edit').click({ force: true });
 
       // Wait for input to load and then type in the new monitor name
-      cy.get('input[name="name"]').focus().clear().type(UPDATED_MONITOR, { force: true });
+      cy.get('input[name="name"]')
+        .should('have.value', SAMPLE_MONITOR)
+        .clear()
+        .type(UPDATED_MONITOR, { force: true });
 
       // Click Update button
       cy.get('button').contains('Update').last().click({ force: true });
@@ -106,15 +105,11 @@ describe('Monitors', () => {
       // Confirm we can see the updated monitor in the list
       cy.contains(UPDATED_MONITOR);
     });
-
-    after(() => {
-      cy.deleteMonitorByName(UPDATED_MONITOR);
-    });
   });
 
   describe('can be deleted', () => {
     before(() => {
-      sampleMonitor.name = SAMPLE_MONITOR;
+      cy.deleteAllMonitors();
       cy.createMonitor(sampleMonitor);
     });
 
@@ -134,17 +129,11 @@ describe('Monitors', () => {
       // Confirm we can see an empty monitor list
       cy.contains('There are no existing monitors');
     });
-
-    // after(() => {
-    //   cy.deleteMonitorByName(SAMPLE_MONITOR);
-    // })
   });
 
   describe('can be searched', () => {
     before(() => {
-      // Modify the monitor's name to be unique
-      sampleMonitor.name = SAMPLE_MONITOR;
-      sampleMonitorWithAlwaysTrueTrigger.name = SAMPLE_MONITOR_WITH_ANOTHER_NAME;
+      cy.deleteAllMonitors();
       // Create 21 monitors so that a monitor will not appear in the first page
       for (let i = 0; i < 20; i++) {
         cy.createMonitor(sampleMonitor);
@@ -168,19 +157,12 @@ describe('Monitors', () => {
         expect($tr, 'item').to.contain(SAMPLE_MONITOR_WITH_ANOTHER_NAME);
       });
     });
-
-    after(() => {
-      for (let i = 0; i < 20; i++) {
-        cy.deleteMonitorByName(SAMPLE_MONITOR);
-      }
-      cy.deleteMonitorByName(SAMPLE_MONITOR_WITH_ANOTHER_NAME);
-    });
   });
 
   describe('can have triggers', () => {
     before(() => {
-      //cy.deleteAllIndices();
-      sampleMonitor.name = SAMPLE_MONITOR;
+      cy.deleteAllMonitors();
+      cy.deleteAllDestinations();
       cy.createMonitor(sampleMonitor);
     });
 
@@ -258,9 +240,11 @@ describe('Monitors', () => {
       // Confirm we can see the new action
       cy.contains(SAMPLE_ACTION);
     });
+  });
 
-    // after(() => {
-    //   cy.deleteMonitorByName(SAMPLE_MONITOR);
-    // })
+  after(() => {
+    // Delete all existing monitors and destinations
+    cy.deleteAllMonitors();
+    cy.deleteAllDestinations();
   });
 });

--- a/cypress/integration/monitor_spec.js
+++ b/cypress/integration/monitor_spec.js
@@ -39,10 +39,11 @@ describe('Monitors', () => {
   });
 
   describe.only('can be created', () => {
-    it('defining by extraction query', () => {
-      // Confirm we loaded empty monitor list
-      // cy.contains('There are no existing monitors');
+    before(() => {
+      cy.deleteAllMonitors2();
+    });
 
+    it('defining by extraction query', () => {
       // Route us to create monitor page
       cy.contains('Create monitor').click({ force: true });
 
@@ -67,11 +68,15 @@ describe('Monitors', () => {
       // Confirm we can see the created monitor in the list
       cy.contains(SAMPLE_MONITOR);
     });
+
+    after(() => {
+      cy.deleteMonitorByName(SAMPLE_MONITOR);
+    });
   });
 
   describe('can be updated', () => {
     before(() => {
-      //cy.deleteAllIndices();
+      cy.deleteAllMonitors2();
       sampleMonitor.name = SAMPLE_MONITOR; // Modify the monitor's name to be unique
       cy.createMonitor(sampleMonitor);
     });
@@ -101,11 +106,15 @@ describe('Monitors', () => {
       // Confirm we can see the updated monitor in the list
       cy.contains(UPDATED_MONITOR);
     });
+
+    after(() => {
+      cy.deleteMonitorByName(UPDATED_MONITOR);
+    });
   });
 
   describe('can be deleted', () => {
     before(() => {
-      cy.deleteAllIndices();
+      sampleMonitor.name = SAMPLE_MONITOR;
       cy.createMonitor(sampleMonitor);
     });
 
@@ -125,11 +134,17 @@ describe('Monitors', () => {
       // Confirm we can see an empty monitor list
       cy.contains('There are no existing monitors');
     });
+
+    // after(() => {
+    //   cy.deleteMonitorByName(SAMPLE_MONITOR);
+    // })
   });
 
   describe('can be searched', () => {
     before(() => {
-      cy.deleteAllIndices();
+      // Modify the monitor's name to be unique
+      sampleMonitor.name = SAMPLE_MONITOR;
+      sampleMonitorWithAlwaysTrueTrigger.name = SAMPLE_MONITOR_WITH_ANOTHER_NAME;
       // Create 21 monitors so that a monitor will not appear in the first page
       for (let i = 0; i < 20; i++) {
         cy.createMonitor(sampleMonitor);
@@ -153,11 +168,19 @@ describe('Monitors', () => {
         expect($tr, 'item').to.contain(SAMPLE_MONITOR_WITH_ANOTHER_NAME);
       });
     });
+
+    after(() => {
+      for (let i = 0; i < 20; i++) {
+        cy.deleteMonitorByName(SAMPLE_MONITOR);
+      }
+      cy.deleteMonitorByName(SAMPLE_MONITOR_WITH_ANOTHER_NAME);
+    });
   });
 
   describe('can have triggers', () => {
     before(() => {
-      cy.deleteAllIndices();
+      //cy.deleteAllIndices();
+      sampleMonitor.name = SAMPLE_MONITOR;
       cy.createMonitor(sampleMonitor);
     });
 
@@ -235,5 +258,9 @@ describe('Monitors', () => {
       // Confirm we can see the new action
       cy.contains(SAMPLE_ACTION);
     });
+
+    // after(() => {
+    //   cy.deleteMonitorByName(SAMPLE_MONITOR);
+    // })
   });
 });

--- a/cypress/integration/monitor_spec.js
+++ b/cypress/integration/monitor_spec.js
@@ -18,11 +18,13 @@ import sampleMonitor from '../fixtures/sample_monitor';
 import sampleMonitorWithAlwaysTrueTrigger from '../fixtures/sample_monitor_with_always_true_trigger';
 import sampleDestination from '../fixtures/sample_destination_custom_webhook.json';
 
-const SAMPLE_MONITOR = 'sample_monitor';
-const UPDATED_MONITOR = 'updated_monitor';
-const SAMPLE_MONITOR_WITH_ANOTHER_NAME = 'sample_monitor_with_always_true_trigger';
-const SAMPLE_TRIGGER = 'sample_trigger';
-const SAMPLE_ACTION = 'sample_action';
+const SAMPLE_MONITOR = `sample_monitor-${Cypress.config('unique_number')}`;
+const UPDATED_MONITOR = `updated_monitor-${Cypress.config('unique_number')}`;
+const SAMPLE_MONITOR_WITH_ANOTHER_NAME = `sample_monitor_with_always_true_trigger-${Cypress.config(
+  'unique_number'
+)}`;
+const SAMPLE_TRIGGER = `sample_trigger-${Cypress.config('unique_number')}`;
+const SAMPLE_ACTION = `sample_action-${Cypress.config('unique_number')}`;
 
 describe('Monitors', () => {
   beforeEach(() => {
@@ -36,14 +38,10 @@ describe('Monitors', () => {
     cy.contains('Create monitor', { timeout: 20000 });
   });
 
-  describe('can be created', () => {
-    before(() => {
-      cy.deleteAllIndices();
-    });
-
+  describe.only('can be created', () => {
     it('defining by extraction query', () => {
       // Confirm we loaded empty monitor list
-      cy.contains('There are no existing monitors');
+      // cy.contains('There are no existing monitors');
 
       // Route us to create monitor page
       cy.contains('Create monitor').click({ force: true });
@@ -73,7 +71,8 @@ describe('Monitors', () => {
 
   describe('can be updated', () => {
     before(() => {
-      cy.deleteAllIndices();
+      //cy.deleteAllIndices();
+      sampleMonitor.name = SAMPLE_MONITOR; // Modify the monitor's name to be unique
       cy.createMonitor(sampleMonitor);
     });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-const { API, INDEX } = require('./constants');
+const { API, INDEX, ADMIN_AUTH } = require('./constants');
 
 // ***********************************************
 // This example commands.js shows you how to
@@ -42,11 +42,14 @@ const { API, INDEX } = require('./constants');
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+  // Add the basic auth header when security enabled in the Elasticsearch cluster
+  // https://github.com/cypress-io/cypress/issues/1288
   if (Cypress.env('security_enabled')) {
     const auth = {
       username: 'admin',
       password: 'admin',
     };
+
     if (options) {
       options.auth = auth;
     } else {
@@ -58,13 +61,13 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
   }
 });
 
+// Be able to add default options to cy.request(), https://github.com/cypress-io/cypress/issues/726
 Cypress.Commands.overwrite('request', (originalFn, ...args) => {
-  const defaults = {
-    auth: {
-      user: 'admin',
-      pass: 'admin',
-    },
-  };
+  let defaults = {};
+  // Add the basic auth header when security enabled in the Elasticsearch cluster
+  if (Cypress.env('security_enabled')) {
+    defaults.auth = ADMIN_AUTH;
+  }
 
   let options = {};
   if (typeof args[0] === 'object' && args[0] !== null) {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -117,3 +117,44 @@ Cypress.Commands.add('createAndExecuteMonitor', (monitorJSON) => {
     }
   );
 });
+
+Cypress.Commands.add('deleteMonitorByName', (monitorName) => {
+  const body = {
+    query: {
+      match: {
+        'monitor.name': {
+          query: monitorName,
+          operator: 'and',
+        },
+      },
+    },
+  };
+  cy.request('GET', `${Cypress.env('elasticsearch')}${API.MONITOR_BASE}/_search`, body).then(
+    (response) => {
+      // response.body is automatically serialized into JSON
+      cy.request(
+        'DELETE',
+        `${Cypress.env('elasticsearch')}${API.MONITOR_BASE}/${response.body.hits.hits[0]._id}`
+      );
+    }
+  );
+});
+
+Cypress.Commands.add('deleteAllMonitors2', (monitorName) => {
+  const body = {
+    query: {
+      match_all: {},
+    },
+  };
+  cy.request('GET', `${Cypress.env('elasticsearch')}${API.MONITOR_BASE}/_search`, body).then(
+    (response) => {
+      // response.body is automatically serialized into JSON
+      for (let i = 0; i < response.body.hits.total.value; i++) {
+        cy.request(
+          'DELETE',
+          `${Cypress.env('elasticsearch')}${API.MONITOR_BASE}/${response.body.hits.hits[i]._id}`
+        );
+      }
+    }
+  );
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -153,3 +153,19 @@ Cypress.Commands.add('deleteAllDestinations', () => {
     }
   );
 });
+
+Cypress.Commands.add('createIndexByName', (indexName) => {
+  cy.request('PUT', `${Cypress.env('elasticsearch')}/${indexName}`);
+});
+
+Cypress.Commands.add('deleteIndexByName', (indexName) => {
+  cy.request('DELETE', `${Cypress.env('elasticsearch')}/${indexName}`);
+});
+
+Cypress.Commands.add('insertDocumentToIndex', (indexName, documentId, documentBody) => {
+  cy.request(
+    'PUT',
+    `${Cypress.env('elasticsearch')}/${indexName}/_doc/${documentId}`,
+    documentBody
+  );
+});

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -25,3 +25,8 @@ export const API = {
 };
 
 export const PLUGIN_NAME = 'opendistro-alerting';
+
+export const ADMIN_AUTH = {
+  username: 'admin',
+  password: 'admin',
+};

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -47,6 +47,3 @@ Cypress.on('uncaught:exception', (err) => {
 if (Cypress.env('security_enabled')) {
   Cypress.env('elasticsearch', 'https://localhost:9200');
 }
-
-// Generate a unique number by getting a unix timestamp in milliseconds ('Date' is not applicable in IE 8 and older)
-Cypress.config('unique_number', `${Date.now()}`);

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -42,3 +42,11 @@ Cypress.on('uncaught:exception', (err) => {
     return false;
   }
 });
+
+// Switch the base URL of Elasticsearch when security enabled in the cluster
+if (Cypress.env('security_enabled')) {
+  Cypress.env('elasticsearch', 'https://localhost:9200');
+}
+
+// Generate a unique number by getting a unix timestamp in milliseconds ('Date' is not applicable in IE 8 and older)
+Cypress.config('unique_number', `${Date.now()}`);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Result for running `cypress run --env security_enabled=true` in an ODFE cluster with security enabled:
```
       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  alert_spec.js                            02:30        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  destination_spec.js                      00:30        4        4        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  monitor_spec.js                          00:40        6        6        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        03:42       15       15        -        -        -  

```

Result for running `cypress run` in an Elasticsearch cluster with only Alerting plugin:
```
       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  alert_spec.js                            02:24        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  destination_spec.js                      00:29        4        4        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  monitor_spec.js                          00:26        6        6        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        03:20       15       15        -        -        -  

```

Result for running `yarn test:jest`
```
Test Suites: 6 skipped, 83 passed, 83 of 89 total
Tests:       20 skipped, 385 passed, 405 total
Snapshots:   135 passed, 135 total
Time:        61.195 s
Ran all test suites.
✨  Done in 62.55s.
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
