### PR TITLE
Upgrade Formik to v2.x to reduce vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "brace": "0.11.1",
-    "formik": "1.1.1",
+    "formik": "^2.2.5",
     "lodash": "^4.17.20",
     "query-string": "^6.13.2",
     "react-router-dom": "^5.2.0",

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.test.js
@@ -28,9 +28,6 @@ const dataTypes = {
   text: new Set(['cityName']),
   keyword: new Set(['cityName.keyword']),
 };
-// Used to wait until all of the promises have cleared, especially waiting for asynchronous Formik's handlers.
-const runAllPromises = () => new Promise(setImmediate);
-
 const openExpression = jest.fn();
 const closeExpression = jest.fn();
 const getMountWrapper = (state = false) => (
@@ -80,7 +77,6 @@ describe('WhereExpression', () => {
       .simulate('keyDown', { key: 'Enter' })
       .simulate('blur');
 
-    await runAllPromises();
     wrapper.update();
     const values = wrapper.find(WhereExpression).props().formik.values;
     expect(values.where.fieldName).toEqual([{ label: 'cityName', type: 'text' }]);

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.test.js
@@ -28,6 +28,9 @@ const dataTypes = {
   text: new Set(['cityName']),
   keyword: new Set(['cityName.keyword']),
 };
+// Used to wait until all of the promises have cleared, especially waiting for asynchronous Formik's handlers.
+const runAllPromises = () => new Promise(setImmediate);
+
 const openExpression = jest.fn();
 const closeExpression = jest.fn();
 const getMountWrapper = (state = false) => (
@@ -67,7 +70,7 @@ describe('WhereExpression', () => {
     button.simulate('keyDown', { keyCode: 27 });
     expect(closeExpression).toHaveBeenCalled();
   });
-  test('should render text input for the text data types', () => {
+  test('should render text input for the text data types', async () => {
     const wrapper = mount(getMountWrapper(true));
     wrapper
       .find('[data-test-subj="comboBoxSearchInput"]')
@@ -77,6 +80,7 @@ describe('WhereExpression', () => {
       .simulate('keyDown', { key: 'Enter' })
       .simulate('blur');
 
+    await runAllPromises();
     wrapper.update();
     const values = wrapper.find(WhereExpression).props().formik.values;
     expect(values.where.fieldName).toEqual([{ label: 'cityName', type: 'text' }]);

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/AnomalyDetector.test.js
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/AnomalyDetector.test.js
@@ -14,7 +14,6 @@
  */
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { Formik } from 'formik';
 import { mount } from 'enzyme';
 
@@ -22,6 +21,9 @@ import { FORMIK_INITIAL_VALUES } from '../../CreateMonitor/utils/constants';
 import AnomalyDetectors from '../AnomalyDetectors';
 import { httpClientMock } from '../../../../../../test/mocks';
 import { CoreContext } from '../../../../../utils/CoreContext';
+
+// Used to wait until all of the promises have cleared, especially waiting for asynchronous Formik's handlers.
+const runAllPromises = () => new Promise(setImmediate);
 
 const renderEmptyMessage = jest.fn();
 function getMountWrapper() {
@@ -62,13 +64,9 @@ describe('AnomalyDetectors', () => {
     wrapper
       .find('[data-test-subj="comboBoxSearchInput"]')
       .hostNodes()
-      .simulate('change', { target: { value: 'sample-detector' } });
+      .simulate('change', { target: { value: 'sample-' } });
 
-    // Enzyme's change event is synchronous and Formik's handlers are asynchronous
-    // https://github.com/formium/formik/issues/937
-    await new Promise((resolve) => {
-      setTimeout(resolve);
-    });
+    await runAllPromises();
 
     wrapper
       .find('[data-test-subj="comboBoxInput"]')
@@ -76,21 +74,9 @@ describe('AnomalyDetectors', () => {
       .simulate('keyDown', { key: 'ArrowDown' })
       .simulate('keyDown', { key: 'Enter' });
 
-    // Validate nothing is in the search input field
-    expect(
-      wrapper.find('[data-test-subj="comboBoxSearchInput"]').hostNodes().props().value
-    ).toEqual('');
     // Validate the specific detector is in the input field
     expect(wrapper.find('[data-test-subj="comboBoxInput"]').hostNodes().text()).toEqual(
       'sample-detector'
     );
   });
 });
-
-const runAllPromises = () => {
-  return new Promise((resolve) => {
-    setImmediate(() => {
-      resolve();
-    });
-  });
-};

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/AnomalyDetector.test.js
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/AnomalyDetector.test.js
@@ -74,7 +74,6 @@ describe('AnomalyDetectors', () => {
       .simulate('keyDown', { key: 'ArrowDown' })
       .simulate('keyDown', { key: 'Enter' });
 
-    console.log(wrapper.instance());
     // Validate the specific detector is in the input field
     expect(wrapper.find('[data-test-subj="comboBoxInput"]').hostNodes().text()).toEqual(
       'sample-detector'

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/AnomalyDetector.test.js
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/AnomalyDetector.test.js
@@ -64,7 +64,11 @@ describe('AnomalyDetectors', () => {
         .simulate('change', { target: { value: 'sample-detector' } })
         .simulate('keyDown', { key: 'ArrowDown' })
         .simulate('keyDown', { key: 'Enter' });
-      expect(wrapper.instance().state.values.detectorId).toEqual('sample-id');
+      // wip
+      expect(wrapper.find('[data-test-subj="comboBoxSearchInput"]').hostNodes().text()).toEqual(
+        'sample-id'
+      );
+      //expect(wrapper.find(AnomalyDetectors).instance().state.detectorOptions[0].value).toEqual('sample-id');
       done();
     });
   });

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/AnomalyDetector.test.js
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/AnomalyDetector.test.js
@@ -64,7 +64,7 @@ describe('AnomalyDetectors', () => {
     wrapper
       .find('[data-test-subj="comboBoxSearchInput"]')
       .hostNodes()
-      .simulate('change', { target: { value: 'sample-' } });
+      .simulate('change', { target: { value: 'sample-detect' } });
 
     await runAllPromises();
 
@@ -74,6 +74,7 @@ describe('AnomalyDetectors', () => {
       .simulate('keyDown', { key: 'ArrowDown' })
       .simulate('keyDown', { key: 'Enter' });
 
+    console.log(wrapper.instance());
     // Validate the specific detector is in the input field
     expect(wrapper.find('[data-test-subj="comboBoxInput"]').hostNodes().text()).toEqual(
       'sample-detector'

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/__snapshots__/AnomalyDetector.test.js.snap
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/__snapshots__/AnomalyDetector.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`AnomalyDetectors renders 1`] = `
 <Formik
-  enableReinitialize={false}
   initialValues={
     Object {
       "aggregationType": "count",
@@ -54,10 +53,7 @@ exports[`AnomalyDetectors renders 1`] = `
       },
     }
   }
-  isInitialValid={false}
   render={[Function]}
-  validateOnBlur={true}
-  validateOnChange={true}
 >
   <AnomalyDetectors
     renderEmptyMessage={[MockFunction]}
@@ -158,20 +154,26 @@ exports[`AnomalyDetectors renders 1`] = `
           name="detectorId"
           render={[Function]}
         >
-          <C
+          <Field
             name="detectorId"
             render={[Function]}
             validate={[Function]}
           >
-            <FieldInner
-              formik={
+            <FormikFormRow
+              form={
                 Object {
                   "dirty": false,
                   "errors": Object {},
+                  "getFieldHelpers": [Function],
+                  "getFieldMeta": [Function],
+                  "getFieldProps": [Function],
                   "handleBlur": [Function],
                   "handleChange": [Function],
                   "handleReset": [Function],
                   "handleSubmit": [Function],
+                  "initialErrors": Object {},
+                  "initialStatus": undefined,
+                  "initialTouched": Object {},
                   "initialValues": Object {
                     "aggregationType": "count",
                     "bucketUnitOfTime": "h",
@@ -222,11 +224,10 @@ exports[`AnomalyDetectors renders 1`] = `
                     },
                   },
                   "isSubmitting": false,
-                  "isValid": false,
+                  "isValid": true,
                   "isValidating": false,
                   "registerField": [Function],
                   "resetForm": [Function],
-                  "setError": [Function],
                   "setErrors": [Function],
                   "setFieldError": [Function],
                   "setFieldTouched": [Function],
@@ -236,16 +237,16 @@ exports[`AnomalyDetectors renders 1`] = `
                   "setSubmitting": [Function],
                   "setTouched": [Function],
                   "setValues": [Function],
+                  "status": undefined,
                   "submitCount": 0,
                   "submitForm": [Function],
                   "touched": Object {},
                   "unregisterField": [Function],
-                  "validate": undefined,
                   "validateField": [Function],
                   "validateForm": [Function],
                   "validateOnBlur": true,
                   "validateOnChange": true,
-                  "validationSchema": undefined,
+                  "validateOnMount": false,
                   "values": Object {
                     "aggregationType": "count",
                     "bucketUnitOfTime": "h",
@@ -298,549 +299,419 @@ exports[`AnomalyDetectors renders 1`] = `
                 }
               }
               name="detectorId"
-              render={[Function]}
-              validate={[Function]}
+              rowProps={
+                Object {
+                  "error": [Function],
+                  "isInvalid": [Function],
+                  "label": "Detector",
+                }
+              }
             >
-              <FormikFormRow
-                form={
-                  Object {
-                    "dirty": false,
-                    "errors": Object {},
-                    "handleBlur": [Function],
-                    "handleChange": [Function],
-                    "handleReset": [Function],
-                    "handleSubmit": [Function],
-                    "initialValues": Object {
-                      "aggregationType": "count",
-                      "bucketUnitOfTime": "h",
-                      "bucketValue": 1,
-                      "cronExpression": "0 */1 * * *",
-                      "daily": 0,
-                      "detectorId": "",
-                      "disabled": false,
-                      "fieldName": Array [],
-                      "frequency": "interval",
-                      "groupedOverFieldName": "bytes",
-                      "groupedOverTop": 5,
-                      "index": Array [],
-                      "monthly": Object {
-                        "day": 1,
-                        "type": "day",
-                      },
-                      "name": "",
-                      "overDocuments": "all documents",
-                      "period": Object {
-                        "interval": 1,
-                        "unit": "MINUTES",
-                      },
-                      "query": "{
-    \\"size\\": 0,
-    \\"query\\": {
-        \\"match_all\\": {}
-    }
-}",
-                      "searchType": "graph",
-                      "timeField": "",
-                      "timezone": Array [],
-                      "weekly": Object {
-                        "fri": false,
-                        "mon": false,
-                        "sat": false,
-                        "sun": false,
-                        "thur": false,
-                        "tue": false,
-                        "wed": false,
-                      },
-                      "where": Object {
-                        "fieldName": Array [],
-                        "fieldRangeEnd": 0,
-                        "fieldRangeStart": 0,
-                        "fieldValue": "",
-                        "operator": "is",
-                      },
-                    },
-                    "isSubmitting": false,
-                    "isValid": false,
-                    "isValidating": false,
-                    "registerField": [Function],
-                    "resetForm": [Function],
-                    "setError": [Function],
-                    "setErrors": [Function],
-                    "setFieldError": [Function],
-                    "setFieldTouched": [Function],
-                    "setFieldValue": [Function],
-                    "setFormikState": [Function],
-                    "setStatus": [Function],
-                    "setSubmitting": [Function],
-                    "setTouched": [Function],
-                    "setValues": [Function],
-                    "submitCount": 0,
-                    "submitForm": [Function],
-                    "touched": Object {},
-                    "unregisterField": [Function],
-                    "validateField": [Function],
-                    "validateForm": [Function],
-                    "validateOnBlur": true,
-                    "validateOnChange": true,
-                    "values": Object {
-                      "aggregationType": "count",
-                      "bucketUnitOfTime": "h",
-                      "bucketValue": 1,
-                      "cronExpression": "0 */1 * * *",
-                      "daily": 0,
-                      "detectorId": "",
-                      "disabled": false,
-                      "fieldName": Array [],
-                      "frequency": "interval",
-                      "groupedOverFieldName": "bytes",
-                      "groupedOverTop": 5,
-                      "index": Array [],
-                      "monthly": Object {
-                        "day": 1,
-                        "type": "day",
-                      },
-                      "name": "",
-                      "overDocuments": "all documents",
-                      "period": Object {
-                        "interval": 1,
-                        "unit": "MINUTES",
-                      },
-                      "query": "{
-    \\"size\\": 0,
-    \\"query\\": {
-        \\"match_all\\": {}
-    }
-}",
-                      "searchType": "graph",
-                      "timeField": "",
-                      "timezone": Array [],
-                      "weekly": Object {
-                        "fri": false,
-                        "mon": false,
-                        "sat": false,
-                        "sun": false,
-                        "thur": false,
-                        "tue": false,
-                        "wed": false,
-                      },
-                      "where": Object {
-                        "fieldName": Array [],
-                        "fieldRangeEnd": 0,
-                        "fieldRangeStart": 0,
-                        "fieldValue": "",
-                        "operator": "is",
-                      },
-                    },
-                  }
-                }
-                name="detectorId"
-                rowProps={
-                  Object {
-                    "error": [Function],
-                    "isInvalid": [Function],
-                    "label": "Detector",
-                  }
-                }
+              <EuiFormRow
+                describedByIds={Array []}
+                display="row"
+                fullWidth={false}
+                hasChildLabel={true}
+                hasEmptyLabelSpace={false}
+                id="detectorId-form-row"
+                isInvalid={false}
+                label="Detector"
+                labelType="label"
               >
-                <EuiFormRow
-                  describedByIds={Array []}
-                  display="row"
-                  fullWidth={false}
-                  hasChildLabel={true}
-                  hasEmptyLabelSpace={false}
-                  id="detectorId-form-row"
-                  isInvalid={false}
-                  label="Detector"
-                  labelType="label"
+                <div
+                  className="euiFormRow"
+                  id="detectorId-form-row-row"
                 >
                   <div
-                    className="euiFormRow"
-                    id="detectorId-form-row-row"
+                    className="euiFormRow__labelWrapper"
                   >
-                    <div
-                      className="euiFormRow__labelWrapper"
+                    <EuiFormLabel
+                      aria-invalid={false}
+                      className="euiFormRow__label"
+                      htmlFor="detectorId-form-row"
+                      isFocused={false}
+                      isInvalid={false}
+                      type="label"
                     >
-                      <EuiFormLabel
+                      <label
                         aria-invalid={false}
-                        className="euiFormRow__label"
+                        className="euiFormLabel euiFormRow__label"
                         htmlFor="detectorId-form-row"
-                        isFocused={false}
-                        isInvalid={false}
-                        type="label"
                       >
-                        <label
-                          aria-invalid={false}
-                          className="euiFormLabel euiFormRow__label"
-                          htmlFor="detectorId-form-row"
-                        >
-                          Detector
-                        </label>
-                      </EuiFormLabel>
-                    </div>
-                    <div
-                      className="euiFormRow__fieldWrapper"
+                        Detector
+                      </label>
+                    </EuiFormLabel>
+                  </div>
+                  <div
+                    className="euiFormRow__fieldWrapper"
+                  >
+                    <ComboBox
+                      field={
+                        Object {
+                          "name": "detectorId",
+                          "onBlur": [Function],
+                          "onChange": [Function],
+                          "value": "",
+                        }
+                      }
+                      form={
+                        Object {
+                          "dirty": false,
+                          "errors": Object {},
+                          "getFieldHelpers": [Function],
+                          "getFieldMeta": [Function],
+                          "getFieldProps": [Function],
+                          "handleBlur": [Function],
+                          "handleChange": [Function],
+                          "handleReset": [Function],
+                          "handleSubmit": [Function],
+                          "initialErrors": Object {},
+                          "initialStatus": undefined,
+                          "initialTouched": Object {},
+                          "initialValues": Object {
+                            "aggregationType": "count",
+                            "bucketUnitOfTime": "h",
+                            "bucketValue": 1,
+                            "cronExpression": "0 */1 * * *",
+                            "daily": 0,
+                            "detectorId": "",
+                            "disabled": false,
+                            "fieldName": Array [],
+                            "frequency": "interval",
+                            "groupedOverFieldName": "bytes",
+                            "groupedOverTop": 5,
+                            "index": Array [],
+                            "monthly": Object {
+                              "day": 1,
+                              "type": "day",
+                            },
+                            "name": "",
+                            "overDocuments": "all documents",
+                            "period": Object {
+                              "interval": 1,
+                              "unit": "MINUTES",
+                            },
+                            "query": "{
+    \\"size\\": 0,
+    \\"query\\": {
+        \\"match_all\\": {}
+    }
+}",
+                            "searchType": "graph",
+                            "timeField": "",
+                            "timezone": Array [],
+                            "weekly": Object {
+                              "fri": false,
+                              "mon": false,
+                              "sat": false,
+                              "sun": false,
+                              "thur": false,
+                              "tue": false,
+                              "wed": false,
+                            },
+                            "where": Object {
+                              "fieldName": Array [],
+                              "fieldRangeEnd": 0,
+                              "fieldRangeStart": 0,
+                              "fieldValue": "",
+                              "operator": "is",
+                            },
+                          },
+                          "isSubmitting": false,
+                          "isValid": true,
+                          "isValidating": false,
+                          "registerField": [Function],
+                          "resetForm": [Function],
+                          "setErrors": [Function],
+                          "setFieldError": [Function],
+                          "setFieldTouched": [Function],
+                          "setFieldValue": [Function],
+                          "setFormikState": [Function],
+                          "setStatus": [Function],
+                          "setSubmitting": [Function],
+                          "setTouched": [Function],
+                          "setValues": [Function],
+                          "status": undefined,
+                          "submitCount": 0,
+                          "submitForm": [Function],
+                          "touched": Object {},
+                          "unregisterField": [Function],
+                          "validateField": [Function],
+                          "validateForm": [Function],
+                          "validateOnBlur": true,
+                          "validateOnChange": true,
+                          "validateOnMount": false,
+                          "values": Object {
+                            "aggregationType": "count",
+                            "bucketUnitOfTime": "h",
+                            "bucketValue": 1,
+                            "cronExpression": "0 */1 * * *",
+                            "daily": 0,
+                            "detectorId": "",
+                            "disabled": false,
+                            "fieldName": Array [],
+                            "frequency": "interval",
+                            "groupedOverFieldName": "bytes",
+                            "groupedOverTop": 5,
+                            "index": Array [],
+                            "monthly": Object {
+                              "day": 1,
+                              "type": "day",
+                            },
+                            "name": "",
+                            "overDocuments": "all documents",
+                            "period": Object {
+                              "interval": 1,
+                              "unit": "MINUTES",
+                            },
+                            "query": "{
+    \\"size\\": 0,
+    \\"query\\": {
+        \\"match_all\\": {}
+    }
+}",
+                            "searchType": "graph",
+                            "timeField": "",
+                            "timezone": Array [],
+                            "weekly": Object {
+                              "fri": false,
+                              "mon": false,
+                              "sat": false,
+                              "sun": false,
+                              "thur": false,
+                              "tue": false,
+                              "wed": false,
+                            },
+                            "where": Object {
+                              "fieldName": Array [],
+                              "fieldRangeEnd": 0,
+                              "fieldRangeStart": 0,
+                              "fieldValue": "",
+                              "operator": "is",
+                            },
+                          },
+                        }
+                      }
+                      id="detectorId-form-row"
+                      inputProps={
+                        Object {
+                          "isClearable": false,
+                          "onBlur": [Function],
+                          "onChange": [Function],
+                          "options": Array [],
+                          "placeholder": "Select a detector",
+                          "selectedOptions": Array [],
+                          "singleSelection": Object {
+                            "asPlaintext": true,
+                          },
+                        }
+                      }
+                      name="detectorId"
+                      onBlur={[Function]}
+                      onFocus={[Function]}
                     >
-                      <ComboBox
-                        field={
-                          Object {
-                            "name": "detectorId",
-                            "onBlur": [Function],
-                            "onChange": [Function],
-                            "value": "",
-                          }
-                        }
-                        form={
-                          Object {
-                            "dirty": false,
-                            "errors": Object {},
-                            "handleBlur": [Function],
-                            "handleChange": [Function],
-                            "handleReset": [Function],
-                            "handleSubmit": [Function],
-                            "initialValues": Object {
-                              "aggregationType": "count",
-                              "bucketUnitOfTime": "h",
-                              "bucketValue": 1,
-                              "cronExpression": "0 */1 * * *",
-                              "daily": 0,
-                              "detectorId": "",
-                              "disabled": false,
-                              "fieldName": Array [],
-                              "frequency": "interval",
-                              "groupedOverFieldName": "bytes",
-                              "groupedOverTop": 5,
-                              "index": Array [],
-                              "monthly": Object {
-                                "day": 1,
-                                "type": "day",
-                              },
-                              "name": "",
-                              "overDocuments": "all documents",
-                              "period": Object {
-                                "interval": 1,
-                                "unit": "MINUTES",
-                              },
-                              "query": "{
-    \\"size\\": 0,
-    \\"query\\": {
-        \\"match_all\\": {}
-    }
-}",
-                              "searchType": "graph",
-                              "timeField": "",
-                              "timezone": Array [],
-                              "weekly": Object {
-                                "fri": false,
-                                "mon": false,
-                                "sat": false,
-                                "sun": false,
-                                "thur": false,
-                                "tue": false,
-                                "wed": false,
-                              },
-                              "where": Object {
-                                "fieldName": Array [],
-                                "fieldRangeEnd": 0,
-                                "fieldRangeStart": 0,
-                                "fieldValue": "",
-                                "operator": "is",
-                              },
-                            },
-                            "isSubmitting": false,
-                            "isValid": false,
-                            "isValidating": false,
-                            "registerField": [Function],
-                            "resetForm": [Function],
-                            "setError": [Function],
-                            "setErrors": [Function],
-                            "setFieldError": [Function],
-                            "setFieldTouched": [Function],
-                            "setFieldValue": [Function],
-                            "setFormikState": [Function],
-                            "setStatus": [Function],
-                            "setSubmitting": [Function],
-                            "setTouched": [Function],
-                            "setValues": [Function],
-                            "submitCount": 0,
-                            "submitForm": [Function],
-                            "touched": Object {},
-                            "unregisterField": [Function],
-                            "validateField": [Function],
-                            "validateForm": [Function],
-                            "validateOnBlur": true,
-                            "validateOnChange": true,
-                            "values": Object {
-                              "aggregationType": "count",
-                              "bucketUnitOfTime": "h",
-                              "bucketValue": 1,
-                              "cronExpression": "0 */1 * * *",
-                              "daily": 0,
-                              "detectorId": "",
-                              "disabled": false,
-                              "fieldName": Array [],
-                              "frequency": "interval",
-                              "groupedOverFieldName": "bytes",
-                              "groupedOverTop": 5,
-                              "index": Array [],
-                              "monthly": Object {
-                                "day": 1,
-                                "type": "day",
-                              },
-                              "name": "",
-                              "overDocuments": "all documents",
-                              "period": Object {
-                                "interval": 1,
-                                "unit": "MINUTES",
-                              },
-                              "query": "{
-    \\"size\\": 0,
-    \\"query\\": {
-        \\"match_all\\": {}
-    }
-}",
-                              "searchType": "graph",
-                              "timeField": "",
-                              "timezone": Array [],
-                              "weekly": Object {
-                                "fri": false,
-                                "mon": false,
-                                "sat": false,
-                                "sun": false,
-                                "thur": false,
-                                "tue": false,
-                                "wed": false,
-                              },
-                              "where": Object {
-                                "fieldName": Array [],
-                                "fieldRangeEnd": 0,
-                                "fieldRangeStart": 0,
-                                "fieldValue": "",
-                                "operator": "is",
-                              },
-                            },
-                          }
-                        }
-                        id="detectorId-form-row"
-                        inputProps={
-                          Object {
-                            "isClearable": false,
-                            "onBlur": [Function],
-                            "onChange": [Function],
-                            "options": Array [],
-                            "placeholder": "Select a detector",
-                            "selectedOptions": Array [],
-                            "singleSelection": Object {
-                              "asPlaintext": true,
-                            },
-                          }
-                        }
+                      <EuiComboBox
+                        async={false}
+                        compressed={false}
+                        fullWidth={false}
+                        id="detectorId"
+                        isClearable={false}
                         name="detectorId"
                         onBlur={[Function]}
-                        onFocus={[Function]}
-                      >
-                        <EuiComboBox
-                          async={false}
-                          compressed={false}
-                          fullWidth={false}
-                          id="detectorId"
-                          isClearable={false}
-                          name="detectorId"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          options={Array []}
-                          placeholder="Select a detector"
-                          selectedOptions={Array []}
-                          singleSelection={
-                            Object {
-                              "asPlaintext": true,
-                            }
+                        onChange={[Function]}
+                        options={Array []}
+                        placeholder="Select a detector"
+                        selectedOptions={Array []}
+                        singleSelection={
+                          Object {
+                            "asPlaintext": true,
                           }
-                          sortMatchesBy="none"
+                        }
+                        sortMatchesBy="none"
+                      >
+                        <div
+                          aria-expanded={false}
+                          aria-haspopup="listbox"
+                          className="euiComboBox"
+                          name="detectorId"
+                          onKeyDown={[Function]}
+                          role="combobox"
                         >
-                          <div
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
-                            className="euiComboBox"
-                            name="detectorId"
-                            onKeyDown={[Function]}
-                            role="combobox"
+                          <EuiComboBoxInput
+                            autoSizeInputRef={[Function]}
+                            compressed={false}
+                            fullWidth={false}
+                            hasSelectedOptions={false}
+                            id="detectorId"
+                            inputRef={[Function]}
+                            isListOpen={false}
+                            noIcon={false}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onCloseListClick={[Function]}
+                            onFocus={[Function]}
+                            onOpenListClick={[Function]}
+                            onRemoveOption={[Function]}
+                            placeholder="Select a detector"
+                            rootId={[Function]}
+                            searchValue=""
+                            selectedOptions={Array []}
+                            singleSelection={
+                              Object {
+                                "asPlaintext": true,
+                              }
+                            }
+                            toggleButtonRef={[Function]}
+                            updatePosition={[Function]}
+                            value=""
                           >
-                            <EuiComboBoxInput
-                              autoSizeInputRef={[Function]}
+                            <EuiFormControlLayout
                               compressed={false}
                               fullWidth={false}
-                              hasSelectedOptions={false}
-                              id="detectorId"
-                              inputRef={[Function]}
-                              isListOpen={false}
-                              noIcon={false}
-                              onChange={[Function]}
-                              onClick={[Function]}
-                              onCloseListClick={[Function]}
-                              onFocus={[Function]}
-                              onOpenListClick={[Function]}
-                              onRemoveOption={[Function]}
-                              placeholder="Select a detector"
-                              rootId={[Function]}
-                              searchValue=""
-                              selectedOptions={Array []}
-                              singleSelection={
+                              icon={
                                 Object {
-                                  "asPlaintext": true,
+                                  "aria-label": "Open list of options",
+                                  "data-test-subj": "comboBoxToggleListButton",
+                                  "disabled": undefined,
+                                  "onClick": [Function],
+                                  "ref": [Function],
+                                  "side": "right",
+                                  "type": "arrowDown",
                                 }
                               }
-                              toggleButtonRef={[Function]}
-                              updatePosition={[Function]}
-                              value=""
                             >
-                              <EuiFormControlLayout
-                                compressed={false}
-                                fullWidth={false}
-                                icon={
-                                  Object {
-                                    "aria-label": "Open list of options",
-                                    "data-test-subj": "comboBoxToggleListButton",
-                                    "disabled": undefined,
-                                    "onClick": [Function],
-                                    "ref": [Function],
-                                    "side": "right",
-                                    "type": "arrowDown",
-                                  }
-                                }
+                              <div
+                                className="euiFormControlLayout"
                               >
                                 <div
-                                  className="euiFormControlLayout"
+                                  className="euiFormControlLayout__childrenWrapper"
                                 >
                                   <div
-                                    className="euiFormControlLayout__childrenWrapper"
+                                    className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                                    data-test-subj="comboBoxInput"
+                                    onClick={[Function]}
+                                    tabIndex={-1}
                                   >
-                                    <div
-                                      className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
-                                      data-test-subj="comboBoxInput"
-                                      onClick={[Function]}
-                                      tabIndex={-1}
+                                    <p
+                                      className="euiComboBoxPlaceholder"
                                     >
-                                      <p
-                                        className="euiComboBoxPlaceholder"
-                                      >
-                                        Select a detector
-                                      </p>
-                                      <AutosizeInput
-                                        aria-controls=""
+                                      Select a detector
+                                    </p>
+                                    <AutosizeInput
+                                      aria-controls=""
+                                      className="euiComboBox__input"
+                                      data-test-subj="comboBoxSearchInput"
+                                      id="detectorId"
+                                      injectStyles={true}
+                                      inputRef={[Function]}
+                                      minWidth={1}
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      role="textbox"
+                                      style={
+                                        Object {
+                                          "fontSize": 14,
+                                        }
+                                      }
+                                      value=""
+                                    >
+                                      <div
                                         className="euiComboBox__input"
-                                        data-test-subj="comboBoxSearchInput"
-                                        id="detectorId"
-                                        injectStyles={true}
-                                        inputRef={[Function]}
-                                        minWidth={1}
-                                        onBlur={[Function]}
-                                        onChange={[Function]}
-                                        onFocus={[Function]}
-                                        role="textbox"
                                         style={
                                           Object {
+                                            "display": "inline-block",
                                             "fontSize": 14,
                                           }
                                         }
-                                        value=""
                                       >
-                                        <div
-                                          className="euiComboBox__input"
+                                        <input
+                                          aria-controls=""
+                                          data-test-subj="comboBoxSearchInput"
+                                          id="detectorId"
+                                          onBlur={[Function]}
+                                          onChange={[Function]}
+                                          onFocus={[Function]}
+                                          role="textbox"
                                           style={
                                             Object {
-                                              "display": "inline-block",
-                                              "fontSize": 14,
+                                              "boxSizing": "content-box",
+                                              "width": "2px",
                                             }
                                           }
-                                        >
-                                          <input
-                                            aria-controls=""
-                                            data-test-subj="comboBoxSearchInput"
-                                            id="detectorId"
-                                            onBlur={[Function]}
-                                            onChange={[Function]}
-                                            onFocus={[Function]}
-                                            role="textbox"
-                                            style={
-                                              Object {
-                                                "boxSizing": "content-box",
-                                                "width": "2px",
-                                              }
+                                          value=""
+                                        />
+                                        <div
+                                          style={
+                                            Object {
+                                              "height": 0,
+                                              "left": 0,
+                                              "overflow": "scroll",
+                                              "position": "absolute",
+                                              "top": 0,
+                                              "visibility": "hidden",
+                                              "whiteSpace": "pre",
                                             }
-                                            value=""
-                                          />
-                                          <div
-                                            style={
-                                              Object {
-                                                "height": 0,
-                                                "left": 0,
-                                                "overflow": "scroll",
-                                                "position": "absolute",
-                                                "top": 0,
-                                                "visibility": "hidden",
-                                                "whiteSpace": "pre",
-                                              }
-                                            }
-                                          />
-                                        </div>
-                                      </AutosizeInput>
-                                    </div>
-                                    <EuiFormControlLayoutIcons
-                                      icon={
-                                        Object {
-                                          "aria-label": "Open list of options",
-                                          "data-test-subj": "comboBoxToggleListButton",
-                                          "disabled": undefined,
-                                          "onClick": [Function],
-                                          "ref": [Function],
-                                          "side": "right",
-                                          "type": "arrowDown",
-                                        }
-                                      }
-                                    >
-                                      <div
-                                        className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                                      >
-                                        <EuiFormControlLayoutCustomIcon
-                                          aria-label="Open list of options"
-                                          data-test-subj="comboBoxToggleListButton"
-                                          iconRef={[Function]}
-                                          onClick={[Function]}
-                                          type="arrowDown"
-                                        >
-                                          <button
-                                            aria-label="Open list of options"
-                                            className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-                                            data-test-subj="comboBoxToggleListButton"
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            <EuiIcon
-                                              aria-hidden="true"
-                                              className="euiFormControlLayoutCustomIcon__icon"
-                                              type="arrowDown"
-                                            >
-                                              <div>
-                                                EuiIconMock
-                                              </div>
-                                            </EuiIcon>
-                                          </button>
-                                        </EuiFormControlLayoutCustomIcon>
+                                          }
+                                        />
                                       </div>
-                                    </EuiFormControlLayoutIcons>
+                                    </AutosizeInput>
                                   </div>
+                                  <EuiFormControlLayoutIcons
+                                    icon={
+                                      Object {
+                                        "aria-label": "Open list of options",
+                                        "data-test-subj": "comboBoxToggleListButton",
+                                        "disabled": undefined,
+                                        "onClick": [Function],
+                                        "ref": [Function],
+                                        "side": "right",
+                                        "type": "arrowDown",
+                                      }
+                                    }
+                                  >
+                                    <div
+                                      className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                    >
+                                      <EuiFormControlLayoutCustomIcon
+                                        aria-label="Open list of options"
+                                        data-test-subj="comboBoxToggleListButton"
+                                        iconRef={[Function]}
+                                        onClick={[Function]}
+                                        type="arrowDown"
+                                      >
+                                        <button
+                                          aria-label="Open list of options"
+                                          className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                          data-test-subj="comboBoxToggleListButton"
+                                          onClick={[Function]}
+                                          type="button"
+                                        >
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiFormControlLayoutCustomIcon__icon"
+                                            type="arrowDown"
+                                          >
+                                            <div>
+                                              EuiIconMock
+                                            </div>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiFormControlLayoutCustomIcon>
+                                    </div>
+                                  </EuiFormControlLayoutIcons>
                                 </div>
-                              </EuiFormControlLayout>
-                            </EuiComboBoxInput>
-                          </div>
-                        </EuiComboBox>
-                      </ComboBox>
-                    </div>
+                              </div>
+                            </EuiFormControlLayout>
+                          </EuiComboBoxInput>
+                        </div>
+                      </EuiComboBox>
+                    </ComboBox>
                   </div>
-                </EuiFormRow>
-              </FormikFormRow>
-            </FieldInner>
-          </C>
+                </div>
+              </EuiFormRow>
+            </FormikFormRow>
+          </Field>
         </FormikInputWrapper>
       </FormikComboBox>
     </div>

--- a/public/pages/CreateMonitor/containers/CreateMonitor/__snapshots__/CreateMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/__snapshots__/CreateMonitor.test.js.snap
@@ -9,7 +9,6 @@ exports[`CreateMonitor renders 1`] = `
   }
 >
   <Formik
-    enableReinitialize={false}
     initialValues={
       Object {
         "aggregationType": "count",
@@ -61,10 +60,8 @@ exports[`CreateMonitor renders 1`] = `
         },
       }
     }
-    isInitialValid={false}
     onSubmit={[Function]}
     render={[Function]}
-    validateOnBlur={true}
     validateOnChange={false}
   />
 </div>

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
@@ -16,6 +16,7 @@
 import React from 'react';
 import { Formik } from 'formik';
 import { mount } from 'enzyme';
+
 import { FORMIK_INITIAL_VALUES } from '../CreateMonitor/utils/constants';
 import MonitorIndex from './MonitorIndex';
 import * as helpers from './utils/helpers';

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
@@ -141,13 +141,7 @@ describe('MonitorIndex', () => {
       .simulate('change', { target: { value: 'l' } })
       .simulate('blur');
 
-    //await new Promise(resolve => { setTimeout(resolve); });
-    //console.log(wrapper.find(MonitorIndex).instance().state)
-    //console.log(wrapper.find('label[htmlFor="index-form-row"]').hostNodes().props()['aria-invalid'])
-    //expect(wrapper.find('label[htmlFor="index-form-row"]').hostNodes().props()['aria-invalid']).toEqual(null)
-
-    // The combobox is expected to only have place holder text
-    //expect(wrapper.find('[data-test-subj="comboBoxInput"]').text()).toEqual('Select indices');
+    expect(wrapper.instance().state.touched).toEqual({ index: true });
   });
 
   test('sets option when calling onCreateOption', () => {
@@ -173,7 +167,6 @@ describe('MonitorIndex', () => {
       wrapper.find('[data-test-subj="comboBoxSearchInput"]').hostNodes().props().value
     ).toEqual('');
     // Validate the specific index is in the input field
-    // TODO: Remove 'EuiIconMock' after the mock for EuiIcon is removed from setup.test.js
     expect(wrapper.find('[data-test-subj="comboBoxInput"]').text()).toEqual(
       'logstash-0EuiIconMock'
     );

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
@@ -166,6 +166,9 @@ describe('MonitorIndex', () => {
       .simulate('keyDown', { key: 'ArrowDown' })
       .simulate('keyDown', { key: 'Enter' });
 
-    expect(wrapper.instance().state.values.index).toEqual([{ label: 'logstash-0' }]);
+    // TODO: Remove 'EuiIconMock' after the mock for EuiIcon is removed from setup.test.js
+    expect(wrapper.find('[data-test-subj="comboBoxInput"]').text()).toEqual(
+      'logstash-0EuiIconMock'
+    );
   });
 });

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
@@ -24,6 +24,10 @@ import { httpClientMock } from '../../../../../test/mocks';
 helpers.createReasonableWait = jest.fn((cb) => cb());
 httpClientMock.post.mockResolvedValue({ ok: true, resp: [] });
 
+// Enzyme's change event is synchronous and Formik's handlers are asynchronous
+// https://github.com/formium/formik/issues/937, https://www.benmvp.com/blog/asynchronous-testing-with-enzyme-react-jest/
+const runAllPromises = () => new Promise(setImmediate);
+
 function getMountWrapper(customProps = {}) {
   return mount(
     <Formik
@@ -156,11 +160,7 @@ describe('MonitorIndex', () => {
       .hostNodes()
       .simulate('change', { target: { value: 'logstash-0' } });
 
-    // Enzyme's change event is synchronous and Formik's handlers are asynchronous
-    // https://github.com/formium/formik/issues/937
-    await new Promise((resolve) => {
-      setTimeout(resolve);
-    });
+    await runAllPromises();
 
     wrapper
       .find('[data-test-subj="comboBoxInput"]')
@@ -168,10 +168,6 @@ describe('MonitorIndex', () => {
       .simulate('keyDown', { key: 'ArrowDown' })
       .simulate('keyDown', { key: 'Enter' });
 
-    // Validate nothing is in the search input field
-    expect(
-      wrapper.find('[data-test-subj="comboBoxSearchInput"]').hostNodes().props().value
-    ).toEqual('');
     // Validate the specific index is in the input field
     expect(wrapper.find('[data-test-subj="comboBoxInput"]').text()).toEqual('logstashEuiIconMock');
   });

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
@@ -144,7 +144,7 @@ describe('MonitorIndex', () => {
     expect(wrapper.instance().state.touched).toEqual({ index: true });
   });
 
-  test('sets option when calling onCreateOption', () => {
+  test('sets option when calling onCreateOption', async () => {
     httpClientMock.post.mockResolvedValue({
       ok: true,
       resp: [{ health: 'green', status: 'open', index: 'logstash-0', alias: 'logstash' }],
@@ -155,6 +155,12 @@ describe('MonitorIndex', () => {
       .find('[data-test-subj="comboBoxSearchInput"]')
       .hostNodes()
       .simulate('change', { target: { value: 'logstash-0' } });
+
+    // Enzyme's change event is synchronous and Formik's handlers are asynchronous
+    // https://github.com/formium/formik/issues/937
+    await new Promise((resolve) => {
+      setTimeout(resolve);
+    });
 
     wrapper
       .find('[data-test-subj="comboBoxInput"]')
@@ -167,8 +173,6 @@ describe('MonitorIndex', () => {
       wrapper.find('[data-test-subj="comboBoxSearchInput"]').hostNodes().props().value
     ).toEqual('');
     // Validate the specific index is in the input field
-    expect(wrapper.find('[data-test-subj="comboBoxInput"]').text()).toEqual(
-      'logstash-0EuiIconMock'
-    );
+    expect(wrapper.find('[data-test-subj="comboBoxInput"]').text()).toEqual('logstashEuiIconMock');
   });
 });

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
@@ -16,7 +16,6 @@
 import React from 'react';
 import { Formik } from 'formik';
 import { mount } from 'enzyme';
-
 import { FORMIK_INITIAL_VALUES } from '../CreateMonitor/utils/constants';
 import MonitorIndex from './MonitorIndex';
 import * as helpers from './utils/helpers';
@@ -43,19 +42,16 @@ describe('MonitorIndex', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  test('calls onSearchChange when changing input value', async () => {
+  test('calls onSearchChange when changing input value', () => {
     const onSearchChange = jest.spyOn(MonitorIndex.prototype, 'onSearchChange');
     const wrapper = getMountWrapper();
     wrapper
       .find('[data-test-subj="comboBoxSearchInput"]')
       .hostNodes()
       .simulate('change', { target: { value: 'random-index' } });
-    setTimeout(() => {
-      wrapper.update();
-      expect(onSearchChange).toHaveBeenCalled();
-      expect(onSearchChange).toHaveBeenCalledWith('random-index');
-      done();
-    });
+
+    expect(onSearchChange).toHaveBeenCalled();
+    expect(onSearchChange).toHaveBeenCalledWith('random-index', false);
   });
 
   test('appends wildcard when search is one valid character', () => {
@@ -145,7 +141,13 @@ describe('MonitorIndex', () => {
       .simulate('change', { target: { value: 'l' } })
       .simulate('blur');
 
-    expect(wrapper.instance().state.touched).toEqual({ index: true });
+    //await new Promise(resolve => { setTimeout(resolve); });
+    //console.log(wrapper.find(MonitorIndex).instance().state)
+    //console.log(wrapper.find('label[htmlFor="index-form-row"]').hostNodes().props()['aria-invalid'])
+    //expect(wrapper.find('label[htmlFor="index-form-row"]').hostNodes().props()['aria-invalid']).toEqual(null)
+
+    // The combobox is expected to only have place holder text
+    //expect(wrapper.find('[data-test-subj="comboBoxInput"]').text()).toEqual('Select indices');
   });
 
   test('sets option when calling onCreateOption', () => {
@@ -166,6 +168,11 @@ describe('MonitorIndex', () => {
       .simulate('keyDown', { key: 'ArrowDown' })
       .simulate('keyDown', { key: 'Enter' });
 
+    // Validate nothing is in the search input field
+    expect(
+      wrapper.find('[data-test-subj="comboBoxSearchInput"]').hostNodes().props().value
+    ).toEqual('');
+    // Validate the specific index is in the input field
     // TODO: Remove 'EuiIconMock' after the mock for EuiIcon is removed from setup.test.js
     expect(wrapper.find('[data-test-subj="comboBoxInput"]').text()).toEqual(
       'logstash-0EuiIconMock'

--- a/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`MonitorIndex renders 1`] = `
 <Formik
-  enableReinitialize={false}
   initialValues={
     Object {
       "aggregationType": "count",
@@ -54,10 +53,7 @@ exports[`MonitorIndex renders 1`] = `
       },
     }
   }
-  isInitialValid={false}
   render={[Function]}
-  validateOnBlur={true}
-  validateOnChange={true}
 >
   <MonitorIndex
     httpClient={[MockFunction]}
@@ -115,20 +111,26 @@ exports[`MonitorIndex renders 1`] = `
         name="index"
         render={[Function]}
       >
-        <C
+        <Field
           name="index"
           render={[Function]}
           validate={[Function]}
         >
-          <FieldInner
-            formik={
+          <FormikFormRow
+            form={
               Object {
                 "dirty": false,
                 "errors": Object {},
+                "getFieldHelpers": [Function],
+                "getFieldMeta": [Function],
+                "getFieldProps": [Function],
                 "handleBlur": [Function],
                 "handleChange": [Function],
                 "handleReset": [Function],
                 "handleSubmit": [Function],
+                "initialErrors": Object {},
+                "initialStatus": undefined,
+                "initialTouched": Object {},
                 "initialValues": Object {
                   "aggregationType": "count",
                   "bucketUnitOfTime": "h",
@@ -179,11 +181,10 @@ exports[`MonitorIndex renders 1`] = `
                   },
                 },
                 "isSubmitting": false,
-                "isValid": false,
+                "isValid": true,
                 "isValidating": false,
                 "registerField": [Function],
                 "resetForm": [Function],
-                "setError": [Function],
                 "setErrors": [Function],
                 "setFieldError": [Function],
                 "setFieldTouched": [Function],
@@ -193,16 +194,16 @@ exports[`MonitorIndex renders 1`] = `
                 "setSubmitting": [Function],
                 "setTouched": [Function],
                 "setValues": [Function],
+                "status": undefined,
                 "submitCount": 0,
                 "submitForm": [Function],
                 "touched": Object {},
                 "unregisterField": [Function],
-                "validate": undefined,
                 "validateField": [Function],
                 "validateForm": [Function],
                 "validateOnBlur": true,
                 "validateOnChange": true,
-                "validationSchema": undefined,
+                "validateOnMount": false,
                 "values": Object {
                   "aggregationType": "count",
                   "bucketUnitOfTime": "h",
@@ -255,165 +256,38 @@ exports[`MonitorIndex renders 1`] = `
               }
             }
             name="index"
-            render={[Function]}
-            validate={[Function]}
-          >
-            <FormikFormRow
-              form={
-                Object {
-                  "dirty": false,
-                  "errors": Object {},
-                  "handleBlur": [Function],
-                  "handleChange": [Function],
-                  "handleReset": [Function],
-                  "handleSubmit": [Function],
-                  "initialValues": Object {
-                    "aggregationType": "count",
-                    "bucketUnitOfTime": "h",
-                    "bucketValue": 1,
-                    "cronExpression": "0 */1 * * *",
-                    "daily": 0,
-                    "detectorId": "",
-                    "disabled": false,
-                    "fieldName": Array [],
-                    "frequency": "interval",
-                    "groupedOverFieldName": "bytes",
-                    "groupedOverTop": 5,
-                    "index": Array [],
-                    "monthly": Object {
-                      "day": 1,
-                      "type": "day",
-                    },
-                    "name": "",
-                    "overDocuments": "all documents",
-                    "period": Object {
-                      "interval": 1,
-                      "unit": "MINUTES",
-                    },
-                    "query": "{
-    \\"size\\": 0,
-    \\"query\\": {
-        \\"match_all\\": {}
-    }
-}",
-                    "searchType": "graph",
-                    "timeField": "",
-                    "timezone": Array [],
-                    "weekly": Object {
-                      "fri": false,
-                      "mon": false,
-                      "sat": false,
-                      "sun": false,
-                      "thur": false,
-                      "tue": false,
-                      "wed": false,
-                    },
-                    "where": Object {
-                      "fieldName": Array [],
-                      "fieldRangeEnd": 0,
-                      "fieldRangeStart": 0,
-                      "fieldValue": "",
-                      "operator": "is",
-                    },
-                  },
-                  "isSubmitting": false,
-                  "isValid": false,
-                  "isValidating": false,
-                  "registerField": [Function],
-                  "resetForm": [Function],
-                  "setError": [Function],
-                  "setErrors": [Function],
-                  "setFieldError": [Function],
-                  "setFieldTouched": [Function],
-                  "setFieldValue": [Function],
-                  "setFormikState": [Function],
-                  "setStatus": [Function],
-                  "setSubmitting": [Function],
-                  "setTouched": [Function],
-                  "setValues": [Function],
-                  "submitCount": 0,
-                  "submitForm": [Function],
-                  "touched": Object {},
-                  "unregisterField": [Function],
-                  "validateField": [Function],
-                  "validateForm": [Function],
-                  "validateOnBlur": true,
-                  "validateOnChange": true,
-                  "values": Object {
-                    "aggregationType": "count",
-                    "bucketUnitOfTime": "h",
-                    "bucketValue": 1,
-                    "cronExpression": "0 */1 * * *",
-                    "daily": 0,
-                    "detectorId": "",
-                    "disabled": false,
-                    "fieldName": Array [],
-                    "frequency": "interval",
-                    "groupedOverFieldName": "bytes",
-                    "groupedOverTop": 5,
-                    "index": Array [],
-                    "monthly": Object {
-                      "day": 1,
-                      "type": "day",
-                    },
-                    "name": "",
-                    "overDocuments": "all documents",
-                    "period": Object {
-                      "interval": 1,
-                      "unit": "MINUTES",
-                    },
-                    "query": "{
-    \\"size\\": 0,
-    \\"query\\": {
-        \\"match_all\\": {}
-    }
-}",
-                    "searchType": "graph",
-                    "timeField": "",
-                    "timezone": Array [],
-                    "weekly": Object {
-                      "fri": false,
-                      "mon": false,
-                      "sat": false,
-                      "sun": false,
-                      "thur": false,
-                      "tue": false,
-                      "wed": false,
-                    },
-                    "where": Object {
-                      "fieldName": Array [],
-                      "fieldRangeEnd": 0,
-                      "fieldRangeStart": 0,
-                      "fieldValue": "",
-                      "operator": "is",
-                    },
-                  },
-                }
+            rowProps={
+              Object {
+                "error": [Function],
+                "helpText": "You can use a * as a wildcard in your index pattern",
+                "isInvalid": [Function],
+                "label": "Index",
+                "style": Object {
+                  "paddingLeft": "10px",
+                },
               }
-              name="index"
-              rowProps={
+            }
+          >
+            <EuiFormRow
+              describedByIds={Array []}
+              display="row"
+              fullWidth={false}
+              hasChildLabel={true}
+              hasEmptyLabelSpace={false}
+              helpText="You can use a * as a wildcard in your index pattern"
+              id="index-form-row"
+              isInvalid={false}
+              label="Index"
+              labelType="label"
+              style={
                 Object {
-                  "error": [Function],
-                  "helpText": "You can use a * as a wildcard in your index pattern",
-                  "isInvalid": [Function],
-                  "label": "Index",
-                  "style": Object {
-                    "paddingLeft": "10px",
-                  },
+                  "paddingLeft": "10px",
                 }
               }
             >
-              <EuiFormRow
-                describedByIds={Array []}
-                display="row"
-                fullWidth={false}
-                hasChildLabel={true}
-                hasEmptyLabelSpace={false}
-                helpText="You can use a * as a wildcard in your index pattern"
-                id="index-form-row"
-                isInvalid={false}
-                label="Index"
-                labelType="label"
+              <div
+                className="euiFormRow"
+                id="index-form-row-row"
                 style={
                   Object {
                     "paddingLeft": "10px",
@@ -421,441 +295,438 @@ exports[`MonitorIndex renders 1`] = `
                 }
               >
                 <div
-                  className="euiFormRow"
-                  id="index-form-row-row"
-                  style={
-                    Object {
-                      "paddingLeft": "10px",
-                    }
-                  }
+                  className="euiFormRow__labelWrapper"
                 >
-                  <div
-                    className="euiFormRow__labelWrapper"
+                  <EuiFormLabel
+                    aria-invalid={false}
+                    className="euiFormRow__label"
+                    htmlFor="index-form-row"
+                    isFocused={false}
+                    isInvalid={false}
+                    type="label"
                   >
-                    <EuiFormLabel
+                    <label
                       aria-invalid={false}
-                      className="euiFormRow__label"
+                      className="euiFormLabel euiFormRow__label"
                       htmlFor="index-form-row"
-                      isFocused={false}
-                      isInvalid={false}
-                      type="label"
                     >
-                      <label
-                        aria-invalid={false}
-                        className="euiFormLabel euiFormRow__label"
-                        htmlFor="index-form-row"
-                      >
-                        Index
-                      </label>
-                    </EuiFormLabel>
-                  </div>
-                  <div
-                    className="euiFormRow__fieldWrapper"
+                      Index
+                    </label>
+                  </EuiFormLabel>
+                </div>
+                <div
+                  className="euiFormRow__fieldWrapper"
+                >
+                  <ComboBox
+                    aria-describedby="index-form-row-help"
+                    field={
+                      Object {
+                        "name": "index",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "value": Array [],
+                      }
+                    }
+                    form={
+                      Object {
+                        "dirty": false,
+                        "errors": Object {},
+                        "getFieldHelpers": [Function],
+                        "getFieldMeta": [Function],
+                        "getFieldProps": [Function],
+                        "handleBlur": [Function],
+                        "handleChange": [Function],
+                        "handleReset": [Function],
+                        "handleSubmit": [Function],
+                        "initialErrors": Object {},
+                        "initialStatus": undefined,
+                        "initialTouched": Object {},
+                        "initialValues": Object {
+                          "aggregationType": "count",
+                          "bucketUnitOfTime": "h",
+                          "bucketValue": 1,
+                          "cronExpression": "0 */1 * * *",
+                          "daily": 0,
+                          "detectorId": "",
+                          "disabled": false,
+                          "fieldName": Array [],
+                          "frequency": "interval",
+                          "groupedOverFieldName": "bytes",
+                          "groupedOverTop": 5,
+                          "index": Array [],
+                          "monthly": Object {
+                            "day": 1,
+                            "type": "day",
+                          },
+                          "name": "",
+                          "overDocuments": "all documents",
+                          "period": Object {
+                            "interval": 1,
+                            "unit": "MINUTES",
+                          },
+                          "query": "{
+    \\"size\\": 0,
+    \\"query\\": {
+        \\"match_all\\": {}
+    }
+}",
+                          "searchType": "graph",
+                          "timeField": "",
+                          "timezone": Array [],
+                          "weekly": Object {
+                            "fri": false,
+                            "mon": false,
+                            "sat": false,
+                            "sun": false,
+                            "thur": false,
+                            "tue": false,
+                            "wed": false,
+                          },
+                          "where": Object {
+                            "fieldName": Array [],
+                            "fieldRangeEnd": 0,
+                            "fieldRangeStart": 0,
+                            "fieldValue": "",
+                            "operator": "is",
+                          },
+                        },
+                        "isSubmitting": false,
+                        "isValid": true,
+                        "isValidating": false,
+                        "registerField": [Function],
+                        "resetForm": [Function],
+                        "setErrors": [Function],
+                        "setFieldError": [Function],
+                        "setFieldTouched": [Function],
+                        "setFieldValue": [Function],
+                        "setFormikState": [Function],
+                        "setStatus": [Function],
+                        "setSubmitting": [Function],
+                        "setTouched": [Function],
+                        "setValues": [Function],
+                        "status": undefined,
+                        "submitCount": 0,
+                        "submitForm": [Function],
+                        "touched": Object {},
+                        "unregisterField": [Function],
+                        "validateField": [Function],
+                        "validateForm": [Function],
+                        "validateOnBlur": true,
+                        "validateOnChange": true,
+                        "validateOnMount": false,
+                        "values": Object {
+                          "aggregationType": "count",
+                          "bucketUnitOfTime": "h",
+                          "bucketValue": 1,
+                          "cronExpression": "0 */1 * * *",
+                          "daily": 0,
+                          "detectorId": "",
+                          "disabled": false,
+                          "fieldName": Array [],
+                          "frequency": "interval",
+                          "groupedOverFieldName": "bytes",
+                          "groupedOverTop": 5,
+                          "index": Array [],
+                          "monthly": Object {
+                            "day": 1,
+                            "type": "day",
+                          },
+                          "name": "",
+                          "overDocuments": "all documents",
+                          "period": Object {
+                            "interval": 1,
+                            "unit": "MINUTES",
+                          },
+                          "query": "{
+    \\"size\\": 0,
+    \\"query\\": {
+        \\"match_all\\": {}
+    }
+}",
+                          "searchType": "graph",
+                          "timeField": "",
+                          "timezone": Array [],
+                          "weekly": Object {
+                            "fri": false,
+                            "mon": false,
+                            "sat": false,
+                            "sun": false,
+                            "thur": false,
+                            "tue": false,
+                            "wed": false,
+                          },
+                          "where": Object {
+                            "fieldName": Array [],
+                            "fieldRangeEnd": 0,
+                            "fieldRangeStart": 0,
+                            "fieldValue": "",
+                            "operator": "is",
+                          },
+                        },
+                      }
+                    }
+                    id="index-form-row"
+                    inputProps={
+                      Object {
+                        "async": true,
+                        "data-test-subj": "indicesComboBox",
+                        "isClearable": true,
+                        "isLoading": true,
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onCreateOption": [Function],
+                        "onSearchChange": [Function],
+                        "options": Array [
+                          Object {
+                            "label": "Aliases",
+                            "options": Array [],
+                          },
+                          Object {
+                            "label": "Indices",
+                            "options": Array [],
+                          },
+                        ],
+                        "placeholder": "Select indices",
+                        "renderOption": [Function],
+                      }
+                    }
+                    name="index"
+                    onBlur={[Function]}
+                    onFocus={[Function]}
                   >
-                    <ComboBox
-                      aria-describedby="index-form-row-help"
-                      field={
-                        Object {
-                          "name": "index",
-                          "onBlur": [Function],
-                          "onChange": [Function],
-                          "value": Array [],
-                        }
-                      }
-                      form={
-                        Object {
-                          "dirty": false,
-                          "errors": Object {},
-                          "handleBlur": [Function],
-                          "handleChange": [Function],
-                          "handleReset": [Function],
-                          "handleSubmit": [Function],
-                          "initialValues": Object {
-                            "aggregationType": "count",
-                            "bucketUnitOfTime": "h",
-                            "bucketValue": 1,
-                            "cronExpression": "0 */1 * * *",
-                            "daily": 0,
-                            "detectorId": "",
-                            "disabled": false,
-                            "fieldName": Array [],
-                            "frequency": "interval",
-                            "groupedOverFieldName": "bytes",
-                            "groupedOverTop": 5,
-                            "index": Array [],
-                            "monthly": Object {
-                              "day": 1,
-                              "type": "day",
-                            },
-                            "name": "",
-                            "overDocuments": "all documents",
-                            "period": Object {
-                              "interval": 1,
-                              "unit": "MINUTES",
-                            },
-                            "query": "{
-    \\"size\\": 0,
-    \\"query\\": {
-        \\"match_all\\": {}
-    }
-}",
-                            "searchType": "graph",
-                            "timeField": "",
-                            "timezone": Array [],
-                            "weekly": Object {
-                              "fri": false,
-                              "mon": false,
-                              "sat": false,
-                              "sun": false,
-                              "thur": false,
-                              "tue": false,
-                              "wed": false,
-                            },
-                            "where": Object {
-                              "fieldName": Array [],
-                              "fieldRangeEnd": 0,
-                              "fieldRangeStart": 0,
-                              "fieldValue": "",
-                              "operator": "is",
-                            },
-                          },
-                          "isSubmitting": false,
-                          "isValid": false,
-                          "isValidating": false,
-                          "registerField": [Function],
-                          "resetForm": [Function],
-                          "setError": [Function],
-                          "setErrors": [Function],
-                          "setFieldError": [Function],
-                          "setFieldTouched": [Function],
-                          "setFieldValue": [Function],
-                          "setFormikState": [Function],
-                          "setStatus": [Function],
-                          "setSubmitting": [Function],
-                          "setTouched": [Function],
-                          "setValues": [Function],
-                          "submitCount": 0,
-                          "submitForm": [Function],
-                          "touched": Object {},
-                          "unregisterField": [Function],
-                          "validateField": [Function],
-                          "validateForm": [Function],
-                          "validateOnBlur": true,
-                          "validateOnChange": true,
-                          "values": Object {
-                            "aggregationType": "count",
-                            "bucketUnitOfTime": "h",
-                            "bucketValue": 1,
-                            "cronExpression": "0 */1 * * *",
-                            "daily": 0,
-                            "detectorId": "",
-                            "disabled": false,
-                            "fieldName": Array [],
-                            "frequency": "interval",
-                            "groupedOverFieldName": "bytes",
-                            "groupedOverTop": 5,
-                            "index": Array [],
-                            "monthly": Object {
-                              "day": 1,
-                              "type": "day",
-                            },
-                            "name": "",
-                            "overDocuments": "all documents",
-                            "period": Object {
-                              "interval": 1,
-                              "unit": "MINUTES",
-                            },
-                            "query": "{
-    \\"size\\": 0,
-    \\"query\\": {
-        \\"match_all\\": {}
-    }
-}",
-                            "searchType": "graph",
-                            "timeField": "",
-                            "timezone": Array [],
-                            "weekly": Object {
-                              "fri": false,
-                              "mon": false,
-                              "sat": false,
-                              "sun": false,
-                              "thur": false,
-                              "tue": false,
-                              "wed": false,
-                            },
-                            "where": Object {
-                              "fieldName": Array [],
-                              "fieldRangeEnd": 0,
-                              "fieldRangeStart": 0,
-                              "fieldValue": "",
-                              "operator": "is",
-                            },
-                          },
-                        }
-                      }
-                      id="index-form-row"
-                      inputProps={
-                        Object {
-                          "async": true,
-                          "data-test-subj": "indicesComboBox",
-                          "isClearable": true,
-                          "isLoading": true,
-                          "onBlur": [Function],
-                          "onChange": [Function],
-                          "onCreateOption": [Function],
-                          "onSearchChange": [Function],
-                          "options": Array [
-                            Object {
-                              "label": "Aliases",
-                              "options": Array [],
-                            },
-                            Object {
-                              "label": "Indices",
-                              "options": Array [],
-                            },
-                          ],
-                          "placeholder": "Select indices",
-                          "renderOption": [Function],
-                        }
-                      }
+                    <EuiComboBox
+                      async={true}
+                      compressed={false}
+                      data-test-subj="indicesComboBox"
+                      fullWidth={false}
+                      id="index"
+                      isClearable={true}
+                      isLoading={true}
                       name="index"
                       onBlur={[Function]}
-                      onFocus={[Function]}
+                      onChange={[Function]}
+                      onCreateOption={[Function]}
+                      onSearchChange={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "label": "Aliases",
+                            "options": Array [],
+                          },
+                          Object {
+                            "label": "Indices",
+                            "options": Array [],
+                          },
+                        ]
+                      }
+                      placeholder="Select indices"
+                      renderOption={[Function]}
+                      selectedOptions={Array []}
+                      singleSelection={false}
+                      sortMatchesBy="none"
                     >
-                      <EuiComboBox
-                        async={true}
-                        compressed={false}
+                      <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
+                        className="euiComboBox"
                         data-test-subj="indicesComboBox"
-                        fullWidth={false}
-                        id="index"
-                        isClearable={true}
-                        isLoading={true}
                         name="index"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onCreateOption={[Function]}
-                        onSearchChange={[Function]}
-                        options={
-                          Array [
-                            Object {
-                              "label": "Aliases",
-                              "options": Array [],
-                            },
-                            Object {
-                              "label": "Indices",
-                              "options": Array [],
-                            },
-                          ]
-                        }
-                        placeholder="Select indices"
-                        renderOption={[Function]}
-                        selectedOptions={Array []}
-                        singleSelection={false}
-                        sortMatchesBy="none"
+                        onKeyDown={[Function]}
+                        role="combobox"
                       >
-                        <div
-                          aria-expanded={false}
-                          aria-haspopup="listbox"
-                          className="euiComboBox"
-                          data-test-subj="indicesComboBox"
-                          name="index"
-                          onKeyDown={[Function]}
-                          role="combobox"
+                        <EuiComboBoxInput
+                          autoSizeInputRef={[Function]}
+                          compressed={false}
+                          fullWidth={false}
+                          hasSelectedOptions={false}
+                          id="index"
+                          inputRef={[Function]}
+                          isListOpen={false}
+                          isLoading={true}
+                          noIcon={false}
+                          onChange={[Function]}
+                          onClear={[Function]}
+                          onClick={[Function]}
+                          onCloseListClick={[Function]}
+                          onFocus={[Function]}
+                          onOpenListClick={[Function]}
+                          onRemoveOption={[Function]}
+                          placeholder="Select indices"
+                          rootId={[Function]}
+                          searchValue=""
+                          selectedOptions={Array []}
+                          singleSelection={false}
+                          toggleButtonRef={[Function]}
+                          updatePosition={[Function]}
+                          value=""
                         >
-                          <EuiComboBoxInput
-                            autoSizeInputRef={[Function]}
+                          <EuiFormControlLayout
                             compressed={false}
                             fullWidth={false}
-                            hasSelectedOptions={false}
-                            id="index"
-                            inputRef={[Function]}
-                            isListOpen={false}
-                            isLoading={true}
-                            noIcon={false}
-                            onChange={[Function]}
-                            onClear={[Function]}
-                            onClick={[Function]}
-                            onCloseListClick={[Function]}
-                            onFocus={[Function]}
-                            onOpenListClick={[Function]}
-                            onRemoveOption={[Function]}
-                            placeholder="Select indices"
-                            rootId={[Function]}
-                            searchValue=""
-                            selectedOptions={Array []}
-                            singleSelection={false}
-                            toggleButtonRef={[Function]}
-                            updatePosition={[Function]}
-                            value=""
-                          >
-                            <EuiFormControlLayout
-                              compressed={false}
-                              fullWidth={false}
-                              icon={
-                                Object {
-                                  "aria-label": "Open list of options",
-                                  "data-test-subj": "comboBoxToggleListButton",
-                                  "disabled": undefined,
-                                  "onClick": [Function],
-                                  "ref": [Function],
-                                  "side": "right",
-                                  "type": "arrowDown",
-                                }
+                            icon={
+                              Object {
+                                "aria-label": "Open list of options",
+                                "data-test-subj": "comboBoxToggleListButton",
+                                "disabled": undefined,
+                                "onClick": [Function],
+                                "ref": [Function],
+                                "side": "right",
+                                "type": "arrowDown",
                               }
-                              isLoading={true}
+                            }
+                            isLoading={true}
+                          >
+                            <div
+                              className="euiFormControlLayout"
                             >
                               <div
-                                className="euiFormControlLayout"
+                                className="euiFormControlLayout__childrenWrapper"
                               >
                                 <div
-                                  className="euiFormControlLayout__childrenWrapper"
+                                  className="euiComboBox__inputWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
+                                  data-test-subj="comboBoxInput"
+                                  onClick={[Function]}
+                                  tabIndex={-1}
                                 >
-                                  <div
-                                    className="euiComboBox__inputWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
-                                    data-test-subj="comboBoxInput"
-                                    onClick={[Function]}
-                                    tabIndex={-1}
+                                  <p
+                                    className="euiComboBoxPlaceholder"
                                   >
-                                    <p
-                                      className="euiComboBoxPlaceholder"
-                                    >
-                                      Select indices
-                                    </p>
-                                    <AutosizeInput
-                                      aria-controls=""
+                                    Select indices
+                                  </p>
+                                  <AutosizeInput
+                                    aria-controls=""
+                                    className="euiComboBox__input"
+                                    data-test-subj="comboBoxSearchInput"
+                                    id="index"
+                                    injectStyles={true}
+                                    inputRef={[Function]}
+                                    minWidth={1}
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onFocus={[Function]}
+                                    role="textbox"
+                                    style={
+                                      Object {
+                                        "fontSize": 14,
+                                      }
+                                    }
+                                    value=""
+                                  >
+                                    <div
                                       className="euiComboBox__input"
-                                      data-test-subj="comboBoxSearchInput"
-                                      id="index"
-                                      injectStyles={true}
-                                      inputRef={[Function]}
-                                      minWidth={1}
-                                      onBlur={[Function]}
-                                      onChange={[Function]}
-                                      onFocus={[Function]}
-                                      role="textbox"
                                       style={
                                         Object {
+                                          "display": "inline-block",
                                           "fontSize": 14,
                                         }
                                       }
-                                      value=""
                                     >
-                                      <div
-                                        className="euiComboBox__input"
+                                      <input
+                                        aria-controls=""
+                                        data-test-subj="comboBoxSearchInput"
+                                        id="index"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        role="textbox"
                                         style={
                                           Object {
-                                            "display": "inline-block",
-                                            "fontSize": 14,
+                                            "boxSizing": "content-box",
+                                            "width": "2px",
                                           }
                                         }
-                                      >
-                                        <input
-                                          aria-controls=""
-                                          data-test-subj="comboBoxSearchInput"
-                                          id="index"
-                                          onBlur={[Function]}
-                                          onChange={[Function]}
-                                          onFocus={[Function]}
-                                          role="textbox"
-                                          style={
-                                            Object {
-                                              "boxSizing": "content-box",
-                                              "width": "2px",
-                                            }
+                                        value=""
+                                      />
+                                      <div
+                                        style={
+                                          Object {
+                                            "height": 0,
+                                            "left": 0,
+                                            "overflow": "scroll",
+                                            "position": "absolute",
+                                            "top": 0,
+                                            "visibility": "hidden",
+                                            "whiteSpace": "pre",
                                           }
-                                          value=""
-                                        />
-                                        <div
-                                          style={
-                                            Object {
-                                              "height": 0,
-                                              "left": 0,
-                                              "overflow": "scroll",
-                                              "position": "absolute",
-                                              "top": 0,
-                                              "visibility": "hidden",
-                                              "whiteSpace": "pre",
-                                            }
-                                          }
-                                        />
-                                      </div>
-                                    </AutosizeInput>
-                                  </div>
-                                  <EuiFormControlLayoutIcons
-                                    icon={
-                                      Object {
-                                        "aria-label": "Open list of options",
-                                        "data-test-subj": "comboBoxToggleListButton",
-                                        "disabled": undefined,
-                                        "onClick": [Function],
-                                        "ref": [Function],
-                                        "side": "right",
-                                        "type": "arrowDown",
-                                      }
-                                    }
-                                    isLoading={true}
-                                  >
-                                    <div
-                                      className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                                    >
-                                      <EuiLoadingSpinner
-                                        size="m"
-                                      >
-                                        <span
-                                          className="euiLoadingSpinner euiLoadingSpinner--medium"
-                                        />
-                                      </EuiLoadingSpinner>
-                                      <EuiFormControlLayoutCustomIcon
-                                        aria-label="Open list of options"
-                                        data-test-subj="comboBoxToggleListButton"
-                                        iconRef={[Function]}
-                                        onClick={[Function]}
-                                        type="arrowDown"
-                                      >
-                                        <button
-                                          aria-label="Open list of options"
-                                          className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-                                          data-test-subj="comboBoxToggleListButton"
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiFormControlLayoutCustomIcon__icon"
-                                            type="arrowDown"
-                                          >
-                                            <div>
-                                              EuiIconMock
-                                            </div>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiFormControlLayoutCustomIcon>
+                                        }
+                                      />
                                     </div>
-                                  </EuiFormControlLayoutIcons>
+                                  </AutosizeInput>
                                 </div>
+                                <EuiFormControlLayoutIcons
+                                  icon={
+                                    Object {
+                                      "aria-label": "Open list of options",
+                                      "data-test-subj": "comboBoxToggleListButton",
+                                      "disabled": undefined,
+                                      "onClick": [Function],
+                                      "ref": [Function],
+                                      "side": "right",
+                                      "type": "arrowDown",
+                                    }
+                                  }
+                                  isLoading={true}
+                                >
+                                  <div
+                                    className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                  >
+                                    <EuiLoadingSpinner
+                                      size="m"
+                                    >
+                                      <span
+                                        className="euiLoadingSpinner euiLoadingSpinner--medium"
+                                      />
+                                    </EuiLoadingSpinner>
+                                    <EuiFormControlLayoutCustomIcon
+                                      aria-label="Open list of options"
+                                      data-test-subj="comboBoxToggleListButton"
+                                      iconRef={[Function]}
+                                      onClick={[Function]}
+                                      type="arrowDown"
+                                    >
+                                      <button
+                                        aria-label="Open list of options"
+                                        className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                        data-test-subj="comboBoxToggleListButton"
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiFormControlLayoutCustomIcon__icon"
+                                          type="arrowDown"
+                                        >
+                                          <div>
+                                            EuiIconMock
+                                          </div>
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiFormControlLayoutCustomIcon>
+                                  </div>
+                                </EuiFormControlLayoutIcons>
                               </div>
-                            </EuiFormControlLayout>
-                          </EuiComboBoxInput>
-                        </div>
-                      </EuiComboBox>
-                    </ComboBox>
-                    <EuiFormHelpText
-                      className="euiFormRow__text"
+                            </div>
+                          </EuiFormControlLayout>
+                        </EuiComboBoxInput>
+                      </div>
+                    </EuiComboBox>
+                  </ComboBox>
+                  <EuiFormHelpText
+                    className="euiFormRow__text"
+                    id="index-form-row-help"
+                  >
+                    <div
+                      className="euiFormHelpText euiFormRow__text"
                       id="index-form-row-help"
                     >
-                      <div
-                        className="euiFormHelpText euiFormRow__text"
-                        id="index-form-row-help"
-                      >
-                        You can use a * as a wildcard in your index pattern
-                      </div>
-                    </EuiFormHelpText>
-                  </div>
+                      You can use a * as a wildcard in your index pattern
+                    </div>
+                  </EuiFormHelpText>
                 </div>
-              </EuiFormRow>
-            </FormikFormRow>
-          </FieldInner>
-        </C>
+              </div>
+            </EuiFormRow>
+          </FormikFormRow>
+        </Field>
       </FormikInputWrapper>
     </FormikComboBox>
   </MonitorIndex>

--- a/public/pages/CreateTrigger/components/TriggerExpressions/__snapshots__/TriggerExpressions.test.js.snap
+++ b/public/pages/CreateTrigger/components/TriggerExpressions/__snapshots__/TriggerExpressions.test.js.snap
@@ -59,7 +59,7 @@ exports[`TriggerExpressions renders 1`] = `
               }
             }
           >
-            <C
+            <Field
               render={[Function]}
             />
           </EuiFlexItem>
@@ -71,7 +71,7 @@ exports[`TriggerExpressions renders 1`] = `
               }
             }
           >
-            <C
+            <Field
               render={[Function]}
             />
           </EuiFlexItem>

--- a/public/pages/CreateTrigger/components/TriggerQuery/__snapshots__/TriggerQuery.test.js.snap
+++ b/public/pages/CreateTrigger/components/TriggerQuery/__snapshots__/TriggerQuery.test.js.snap
@@ -33,7 +33,7 @@ exports[`TriggerQuery renders 1`] = `
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem>
-      <C
+      <Field
         name="script.source"
         render={[Function]}
       />

--- a/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/ManageEmailGroups.js
+++ b/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/ManageEmailGroups.js
@@ -71,6 +71,7 @@ export default class ManageEmailGroups extends React.Component {
     super(props);
 
     this.state = {
+      initialValues: {},
       emailGroupsToDelete: [],
       loadingEmailGroups: true,
       failedEmailGroups: false,
@@ -260,7 +261,7 @@ export default class ManageEmailGroups extends React.Component {
     const { initialValues, loadingEmailGroups } = this.state;
     return isVisible ? (
       <Formik
-        initialValues={initialValues || {}}
+        initialValues={initialValues}
         onSubmit={(values, formikBag) => {
           this.processEmailGroups(values).then(() => onClickSave());
         }}

--- a/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/ManageEmailGroups.js
+++ b/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/ManageEmailGroups.js
@@ -260,7 +260,7 @@ export default class ManageEmailGroups extends React.Component {
     const { initialValues, loadingEmailGroups } = this.state;
     return isVisible ? (
       <Formik
-        initialValues={initialValues}
+        initialValues={initialValues || {}}
         onSubmit={(values, formikBag) => {
           this.processEmailGroups(values).then(() => onClickSave());
         }}

--- a/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/ManageEmailGroups.js
+++ b/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/ManageEmailGroups.js
@@ -71,6 +71,7 @@ export default class ManageEmailGroups extends React.Component {
     super(props);
 
     this.state = {
+      // initialValues is required in Formik v2, https://github.com/formium/formik/issues/1967
       initialValues: {},
       emailGroupsToDelete: [],
       loadingEmailGroups: true,

--- a/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/__snapshots__/ManageEmailGroups.test.js.snap
+++ b/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/__snapshots__/ManageEmailGroups.test.js.snap
@@ -19,11 +19,9 @@ exports[`ManageEmailGroups renders when email is disallowed 1`] = `
   onClickSave={[MockFunction]}
 >
   <Formik
-    enableReinitialize={false}
-    isInitialValid={false}
+    initialValues={Object {}}
     onSubmit={[Function]}
     render={[Function]}
-    validateOnBlur={true}
     validateOnChange={false}
   >
     <EuiOverlayMask>
@@ -556,7 +554,7 @@ exports[`ManageEmailGroups renders when email is disallowed 1`] = `
                               <div
                                 className="euiModalBody__overflow"
                               >
-                                <C
+                                <FormikConnect(FieldArrayInner)
                                   name="emailGroups"
                                   render={[Function]}
                                   validateOnChange={true}
@@ -566,17 +564,22 @@ exports[`ManageEmailGroups renders when email is disallowed 1`] = `
                                       Object {
                                         "dirty": false,
                                         "errors": Object {},
+                                        "getFieldHelpers": [Function],
+                                        "getFieldMeta": [Function],
+                                        "getFieldProps": [Function],
                                         "handleBlur": [Function],
                                         "handleChange": [Function],
                                         "handleReset": [Function],
                                         "handleSubmit": [Function],
+                                        "initialErrors": Object {},
+                                        "initialStatus": undefined,
+                                        "initialTouched": Object {},
                                         "initialValues": Object {},
                                         "isSubmitting": false,
-                                        "isValid": false,
+                                        "isValid": true,
                                         "isValidating": false,
                                         "registerField": [Function],
                                         "resetForm": [Function],
-                                        "setError": [Function],
                                         "setErrors": [Function],
                                         "setFieldError": [Function],
                                         "setFieldTouched": [Function],
@@ -586,16 +589,16 @@ exports[`ManageEmailGroups renders when email is disallowed 1`] = `
                                         "setSubmitting": [Function],
                                         "setTouched": [Function],
                                         "setValues": [Function],
+                                        "status": undefined,
                                         "submitCount": 0,
                                         "submitForm": [Function],
                                         "touched": Object {},
                                         "unregisterField": [Function],
-                                        "validate": undefined,
                                         "validateField": [Function],
                                         "validateForm": [Function],
                                         "validateOnBlur": true,
                                         "validateOnChange": false,
-                                        "validationSchema": undefined,
+                                        "validateOnMount": false,
                                         "values": Object {},
                                       }
                                     }
@@ -614,7 +617,7 @@ exports[`ManageEmailGroups renders when email is disallowed 1`] = `
                                       Email is disallowed
                                     </div>
                                   </FieldArrayInner>
-                                </C>
+                                </FormikConnect(FieldArrayInner)>
                               </div>
                             </div>
                           </EuiModalBody>
@@ -705,11 +708,9 @@ exports[`ManageEmailGroups renders when visible 1`] = `
   onClickSave={[MockFunction]}
 >
   <Formik
-    enableReinitialize={false}
-    isInitialValid={false}
+    initialValues={Object {}}
     onSubmit={[Function]}
     render={[Function]}
-    validateOnBlur={true}
     validateOnChange={false}
   >
     <EuiOverlayMask>
@@ -1242,7 +1243,7 @@ exports[`ManageEmailGroups renders when visible 1`] = `
                               <div
                                 className="euiModalBody__overflow"
                               >
-                                <C
+                                <FormikConnect(FieldArrayInner)
                                   name="emailGroups"
                                   render={[Function]}
                                   validateOnChange={true}
@@ -1252,17 +1253,22 @@ exports[`ManageEmailGroups renders when visible 1`] = `
                                       Object {
                                         "dirty": false,
                                         "errors": Object {},
+                                        "getFieldHelpers": [Function],
+                                        "getFieldMeta": [Function],
+                                        "getFieldProps": [Function],
                                         "handleBlur": [Function],
                                         "handleChange": [Function],
                                         "handleReset": [Function],
                                         "handleSubmit": [Function],
+                                        "initialErrors": Object {},
+                                        "initialStatus": undefined,
+                                        "initialTouched": Object {},
                                         "initialValues": Object {},
                                         "isSubmitting": false,
-                                        "isValid": false,
+                                        "isValid": true,
                                         "isValidating": false,
                                         "registerField": [Function],
                                         "resetForm": [Function],
-                                        "setError": [Function],
                                         "setErrors": [Function],
                                         "setFieldError": [Function],
                                         "setFieldTouched": [Function],
@@ -1272,16 +1278,16 @@ exports[`ManageEmailGroups renders when visible 1`] = `
                                         "setSubmitting": [Function],
                                         "setTouched": [Function],
                                         "setValues": [Function],
+                                        "status": undefined,
                                         "submitCount": 0,
                                         "submitForm": [Function],
                                         "touched": Object {},
                                         "unregisterField": [Function],
-                                        "validate": undefined,
                                         "validateField": [Function],
                                         "validateForm": [Function],
                                         "validateOnBlur": true,
                                         "validateOnChange": false,
-                                        "validationSchema": undefined,
+                                        "validateOnMount": false,
                                         "values": Object {},
                                       }
                                     }
@@ -1300,7 +1306,7 @@ exports[`ManageEmailGroups renders when visible 1`] = `
                                       Loading Email Groups...
                                     </div>
                                   </FieldArrayInner>
-                                </C>
+                                </FormikConnect(FieldArrayInner)>
                               </div>
                             </div>
                           </EuiModalBody>

--- a/public/pages/Destinations/containers/CreateDestination/ManageSenders/ManageSenders.js
+++ b/public/pages/Destinations/containers/CreateDestination/ManageSenders/ManageSenders.js
@@ -56,6 +56,7 @@ export default class ManageSenders extends React.Component {
     super(props);
 
     this.state = {
+      initialValues: {},
       sendersToDelete: [],
       loadingSenders: true,
       failedSenders: false,

--- a/public/pages/Destinations/containers/CreateDestination/ManageSenders/ManageSenders.js
+++ b/public/pages/Destinations/containers/CreateDestination/ManageSenders/ManageSenders.js
@@ -56,6 +56,7 @@ export default class ManageSenders extends React.Component {
     super(props);
 
     this.state = {
+      // initialValues is required in Formik v2, https://github.com/formium/formik/issues/1967
       initialValues: {},
       sendersToDelete: [],
       loadingSenders: true,

--- a/public/pages/Destinations/containers/CreateDestination/ManageSenders/ManageSenders.js
+++ b/public/pages/Destinations/containers/CreateDestination/ManageSenders/ManageSenders.js
@@ -56,7 +56,7 @@ export default class ManageSenders extends React.Component {
     super(props);
 
     this.state = {
-      // initialValues is required in Formik v2, https://github.com/formium/formik/issues/1967
+      // initialValues is required in Formik v2, and unit test fails without giving it an object
       initialValues: {},
       sendersToDelete: [],
       loadingSenders: true,

--- a/public/pages/Destinations/containers/CreateDestination/ManageSenders/__snapshots__/ManageSenders.test.js.snap
+++ b/public/pages/Destinations/containers/CreateDestination/ManageSenders/__snapshots__/ManageSenders.test.js.snap
@@ -19,11 +19,9 @@ exports[`ManageSenders renders when email is disallowed 1`] = `
   onClickSave={[MockFunction]}
 >
   <Formik
-    enableReinitialize={false}
-    isInitialValid={false}
+    initialValues={Object {}}
     onSubmit={[Function]}
     render={[Function]}
-    validateOnBlur={true}
     validateOnChange={false}
   >
     <EuiOverlayMask>
@@ -556,7 +554,7 @@ exports[`ManageSenders renders when email is disallowed 1`] = `
                               <div
                                 className="euiModalBody__overflow"
                               >
-                                <C
+                                <FormikConnect(FieldArrayInner)
                                   name="senders"
                                   render={[Function]}
                                   validateOnChange={true}
@@ -566,17 +564,22 @@ exports[`ManageSenders renders when email is disallowed 1`] = `
                                       Object {
                                         "dirty": false,
                                         "errors": Object {},
+                                        "getFieldHelpers": [Function],
+                                        "getFieldMeta": [Function],
+                                        "getFieldProps": [Function],
                                         "handleBlur": [Function],
                                         "handleChange": [Function],
                                         "handleReset": [Function],
                                         "handleSubmit": [Function],
+                                        "initialErrors": Object {},
+                                        "initialStatus": undefined,
+                                        "initialTouched": Object {},
                                         "initialValues": Object {},
                                         "isSubmitting": false,
-                                        "isValid": false,
+                                        "isValid": true,
                                         "isValidating": false,
                                         "registerField": [Function],
                                         "resetForm": [Function],
-                                        "setError": [Function],
                                         "setErrors": [Function],
                                         "setFieldError": [Function],
                                         "setFieldTouched": [Function],
@@ -586,16 +589,16 @@ exports[`ManageSenders renders when email is disallowed 1`] = `
                                         "setSubmitting": [Function],
                                         "setTouched": [Function],
                                         "setValues": [Function],
+                                        "status": undefined,
                                         "submitCount": 0,
                                         "submitForm": [Function],
                                         "touched": Object {},
                                         "unregisterField": [Function],
-                                        "validate": undefined,
                                         "validateField": [Function],
                                         "validateForm": [Function],
                                         "validateOnBlur": true,
                                         "validateOnChange": false,
-                                        "validationSchema": undefined,
+                                        "validateOnMount": false,
                                         "values": Object {},
                                       }
                                     }
@@ -614,7 +617,7 @@ exports[`ManageSenders renders when email is disallowed 1`] = `
                                       Email is disallowed
                                     </div>
                                   </FieldArrayInner>
-                                </C>
+                                </FormikConnect(FieldArrayInner)>
                               </div>
                             </div>
                           </EuiModalBody>
@@ -705,11 +708,9 @@ exports[`ManageSenders renders when visible 1`] = `
   onClickSave={[MockFunction]}
 >
   <Formik
-    enableReinitialize={false}
-    isInitialValid={false}
+    initialValues={Object {}}
     onSubmit={[Function]}
     render={[Function]}
-    validateOnBlur={true}
     validateOnChange={false}
   >
     <EuiOverlayMask>
@@ -1242,7 +1243,7 @@ exports[`ManageSenders renders when visible 1`] = `
                               <div
                                 className="euiModalBody__overflow"
                               >
-                                <C
+                                <FormikConnect(FieldArrayInner)
                                   name="senders"
                                   render={[Function]}
                                   validateOnChange={true}
@@ -1252,17 +1253,22 @@ exports[`ManageSenders renders when visible 1`] = `
                                       Object {
                                         "dirty": false,
                                         "errors": Object {},
+                                        "getFieldHelpers": [Function],
+                                        "getFieldMeta": [Function],
+                                        "getFieldProps": [Function],
                                         "handleBlur": [Function],
                                         "handleChange": [Function],
                                         "handleReset": [Function],
                                         "handleSubmit": [Function],
+                                        "initialErrors": Object {},
+                                        "initialStatus": undefined,
+                                        "initialTouched": Object {},
                                         "initialValues": Object {},
                                         "isSubmitting": false,
-                                        "isValid": false,
+                                        "isValid": true,
                                         "isValidating": false,
                                         "registerField": [Function],
                                         "resetForm": [Function],
-                                        "setError": [Function],
                                         "setErrors": [Function],
                                         "setFieldError": [Function],
                                         "setFieldTouched": [Function],
@@ -1272,16 +1278,16 @@ exports[`ManageSenders renders when visible 1`] = `
                                         "setSubmitting": [Function],
                                         "setTouched": [Function],
                                         "setValues": [Function],
+                                        "status": undefined,
                                         "submitCount": 0,
                                         "submitForm": [Function],
                                         "touched": Object {},
                                         "unregisterField": [Function],
-                                        "validate": undefined,
                                         "validateField": [Function],
                                         "validateForm": [Function],
                                         "validateOnBlur": true,
                                         "validateOnChange": false,
-                                        "validationSchema": undefined,
+                                        "validateOnMount": false,
                                         "values": Object {},
                                       }
                                     }
@@ -1300,7 +1306,7 @@ exports[`ManageSenders renders when visible 1`] = `
                                       Loading Senders...
                                     </div>
                                   </FieldArrayInner>
-                                </C>
+                                </FormikConnect(FieldArrayInner)>
                               </div>
                             </div>
                           </EuiModalBody>

--- a/public/pages/Destinations/containers/CreateDestination/utils/__tests__/validation.test.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/__tests__/validation.test.js
@@ -32,13 +32,13 @@ describe('destinations Validations', () => {
       ).resolves.toBeUndefined();
     });
     test('should reject if name is empty', () => {
-      return expect(validateDestinationName(httpClient, null)('')).rejects.toEqual('Required');
+      return expect(validateDestinationName(httpClient, null)('')).resolves.toEqual('Required');
     });
     test('should reject if name already is being in used', () => {
       httpClient.post.mockResolvedValue({
         resp: { hits: { total: { value: 1, relation: 'eq' } } },
       });
-      return expect(validateDestinationName(httpClient, null)('destinationName')).rejects.toEqual(
+      return expect(validateDestinationName(httpClient, null)('destinationName')).resolves.toEqual(
         'Destination name is already used'
       );
     });
@@ -48,13 +48,13 @@ describe('destinations Validations', () => {
       });
       return expect(
         validateDestinationName(httpClient, { name: 'destinationName' })('destinationName Existing')
-      ).rejects.toEqual('Destination name is already used');
+      ).resolves.toEqual('Destination name is already used');
     });
     test('should rejects if network request has some error', () => {
       httpClient.post.mockRejectedValue({
         resp: { ok: false, error: 'There was an issue' },
       });
-      return expect(validateDestinationName(httpClient, null)('destinationName')).rejects.toEqual(
+      return expect(validateDestinationName(httpClient, null)('destinationName')).resolves.toEqual(
         'There was a problem validating destination name. Please try again.'
       );
     });

--- a/public/pages/Destinations/containers/CreateDestination/utils/validations.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/validations.js
@@ -19,7 +19,7 @@ import { getAllowList } from '../../../utils/helpers';
 
 export const validateDestinationName = (httpClient, destinationToEdit) => async (value) => {
   try {
-    if (!value) throw 'Required';
+    if (!value) return 'Required';
     const options = {
       index: INDEX.SCHEDULED_JOBS,
       query: { query: { term: { 'destination.name.keyword': value } } },
@@ -28,9 +28,9 @@ export const validateDestinationName = (httpClient, destinationToEdit) => async 
       body: JSON.stringify(options),
     });
     if (_.get(response, 'resp.hits.total.value', 0)) {
-      if (!destinationToEdit) throw 'Destination name is already used';
+      if (!destinationToEdit) return 'Destination name is already used';
       if (destinationToEdit && destinationToEdit.name !== value) {
-        throw 'Destination name is already used';
+        return 'Destination name is already used';
       }
     }
     // TODO: Handle the situation that destinations with a same name can be created when user don't have the permission of 'cluster:admin/opendistro/alerting/monitor/search'

--- a/public/pages/Destinations/containers/CreateDestination/utils/validations.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/validations.js
@@ -35,8 +35,8 @@ export const validateDestinationName = (httpClient, destinationToEdit) => async 
     }
     // TODO: Handle the situation that destinations with a same name can be created when user don't have the permission of 'cluster:admin/opendistro/alerting/monitor/search'
   } catch (err) {
-    if (typeof err === 'string') throw err;
-    throw 'There was a problem validating destination name. Please try again.';
+    if (typeof err === 'string') return err;
+    return 'There was a problem validating destination name. Please try again.';
   }
 };
 

--- a/public/utils/validate.js
+++ b/public/utils/validate.js
@@ -51,7 +51,7 @@ export const required = (value) => {
 
 export const validateMonitorName = (httpClient, monitorToEdit) => async (value) => {
   try {
-    if (!value) throw 'Required';
+    if (!value) return 'Required';
     const options = {
       index: INDEX.SCHEDULED_JOBS,
       query: { query: { term: { 'monitor.name.keyword': value } } },
@@ -60,9 +60,9 @@ export const validateMonitorName = (httpClient, monitorToEdit) => async (value) 
       body: JSON.stringify(options),
     });
     if (_.get(response, 'resp.hits.total.value', 0)) {
-      if (!monitorToEdit) throw 'Monitor name is already used';
+      if (!monitorToEdit) return 'Monitor name is already used';
       if (monitorToEdit && monitorToEdit.name !== value) {
-        throw 'Monitor name is already used';
+        return 'Monitor name is already used';
       }
     }
     // TODO: Handle the situation that monitors with a same name can be created when user don't have the permission of 'cluster:admin/opendistro/alerting/monitor/search'

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,11 +214,6 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
-asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
-
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -491,11 +486,6 @@ concat-stream@^1.6.2:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -510,14 +500,6 @@ cosmiconfig@^5.2.1:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
-
-create-react-context@^0.2.2:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
-  integrity sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==
-  dependencies:
-    fbjs "^0.8.0"
-    gud "^1.0.0"
 
 cross-spawn@^6.0.0:
   version "6.0.5"
@@ -801,13 +783,6 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-encoding@^0.1.11:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
-  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
-  dependencies:
-    iconv-lite "^0.6.2"
-
 end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -990,19 +965,6 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-fbjs@^0.8.0:
-  version "0.8.17"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
-  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
-
 fd-slicer@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
@@ -1054,20 +1016,18 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-formik@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formik/-/formik-1.1.1.tgz#078e6b7ff09d040ad63a30058e1ce8f1c0ad59cb"
-  integrity sha512-B1uCqH7+FJn+q7DWp4nBQ7xYoICh01ll4mDPv4Y9emne3IMPmAWj7UR92Td7jxmd+woKkD/3lxJzzb9gWv54HA==
+formik@^2.2.5:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.2.6.tgz#378a4bafe4b95caf6acf6db01f81f3fe5147559d"
+  integrity sha512-Kxk2zQRafy56zhLmrzcbryUpMBvT0tal5IvcifK5+4YNGelKsnrODFJ0sZQRMQboblWNym4lAW3bt+tf2vApSA==
   dependencies:
-    create-react-context "^0.2.2"
     deepmerge "^2.1.1"
-    hoist-non-react-statics "^2.5.5"
-    lodash.clonedeep "^4.5.0"
-    lodash.topath "4.5.2"
-    prop-types "^15.6.1"
-    react-fast-compare "^1.0.0"
-    tslib "^1.9.3"
-    warning "^3.0.0"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.14"
+    lodash-es "^4.17.14"
+    react-fast-compare "^2.0.1"
+    tiny-warning "^1.0.2"
+    tslib "^1.10.0"
 
 fs-extra@^9.0.1:
   version "9.0.1"
@@ -1199,11 +1159,6 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
-  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
-
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -1263,12 +1218,7 @@ hoek@4.2.1:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
   integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
 
-hoist-non-react-statics@^2.5.5:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
-
-hoist-non-react-statics@^3.1.0:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -1310,13 +1260,6 @@ husky@^3.0.0:
     read-pkg "^5.2.0"
     run-node "^1.0.0"
     slash "^3.0.0"
-
-iconv-lite@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
-  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ignore@^5.1.1:
   version "5.1.8"
@@ -1484,7 +1427,7 @@ is-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
   integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -1520,14 +1463,6 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -1677,22 +1612,17 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+lodash-es@^4.17.14:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.20.tgz#29f6332eefc60e849f869c264bc71126ad61e8f7"
+  integrity sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA==
 
 lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash.topath@4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/lodash.topath/-/lodash.topath-4.5.2.tgz#3616351f3bba61994a0931989660bd03254fd009"
-  integrity sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=
-
-lodash@^4.17.19, lodash@^4.17.20:
+lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -1727,7 +1657,7 @@ log-update@^2.3.0:
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
 
-loose-envify@^1.0.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -1832,14 +1762,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -2106,14 +2028,7 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
-
-prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.8, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -2176,10 +2091,10 @@ ramda@~0.26.1:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
   integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
-react-fast-compare@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-1.0.0.tgz#813a039155e49b43ceffe99528fe5e9d97a6c938"
-  integrity sha512-dcQpdWr62flXQJuM8/bVEY5/10ad2SYBUafp8H4q4WHR3fTA/MMlp8mpzX12I0CCoEJc1P6QdiMg7U+7lFS6Rw==
+react-fast-compare@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
@@ -2371,7 +2286,7 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-"safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -2385,11 +2300,6 @@ semver-compare@^1.0.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
-
-setimmediate@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
-  integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -2614,7 +2524,7 @@ tiny-invariant@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
   integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
 
-tiny-warning@^1.0.0, tiny-warning@^1.0.3:
+tiny-warning@^1.0.0, tiny-warning@^1.0.2, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
@@ -2641,7 +2551,7 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -2667,11 +2577,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-ua-parser-js@^0.7.18:
-  version "0.7.22"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.22.tgz#960df60a5f911ea8f1c818f3747b99c6e177eae3"
-  integrity sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==
 
 universalify@^1.0.0:
   version "1.0.0"
@@ -2734,18 +2639,6 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
-
-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
-  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
-  dependencies:
-    loose-envify "^1.0.0"
-
-whatwg-fetch@>=0.10.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz#605a2cd0a7146e5db141e29d1c62ab84c0c4c868"
-  integrity sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==
 
 which@^1.2.9:
   version "1.3.1"


### PR DESCRIPTION
*Issue #, if available:*

There is a vulnerability `CVE-2020-7793` shows that the package `ua-parser-js` before `0.7.23` are vulnerable to Regular Expression Denial of Service (ReDoS) in multiple regexes.

In Alerting Kibana plugin, the dependency relationship of `ua-parser-js` is: 
formik -> create-react-context -> fbjs -> ua-parser-js

Upgrading `Formik` is the way to reduce the vulnerability.

*Description of changes:*

 - Upgrade Formik from `1.1.1` to `^2.2.5` (which is the same as `Anomaly Detection Kibana` plugin [commit](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/commit/ec42b9fa6b62c7f7158b1178535bbcf5e519dbc6), thus the two plugins can be built together in same directory)
 - Change all rejected promise of errors caused by `throw` to resolved promise of errors with `return` in validation functions for Monitor and Destination, according to [Formik v2 migration guide](https://formik.org/docs/migrating-v2#validate), or there will be an error like below.
![v1 to v2 validate promise error](https://user-images.githubusercontent.com/62041081/105402425-40060080-5bdc-11eb-8892-1c30d2f4358a.png)
 - In `ManageEmailGroups.js` and `ManageSender.js`, initialize `initialValues` variable that used for Formik with a empty object, because `initialValues` is [required in Formik v2](https://github.com/formium/formik/issues/1967) and unit test fails with the variable initialization.
 - Fix unit test failure due to the upgrade:
1.  In `MonitorIndex.test.js` and `AnomalyDetector.test.js`, change the assertion step according to the advice [here](https://stackoverflow.com/questions/59475724/how-to-test-methods-inside-functional-component-using-enzyme-as-instance-retur), because Enzyme's `wrapper.instance()` returns `null` so that the Formik values in `state` can't be obtained.
2. In `MonitorIndex.test.js` and `AnomalyDetector.test.js`, modify the logic of the test to wait for asynchronous Formik's handlers, because Enzyme's change event is synchronous. I used the same way as tests related to Email Destination: [commit](https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/commit/329a967b7bd80f6cd68cc1f6ec4c1f64c0deb3fd) 
3. For the test `calls onSearchChange when changing input value` in `MonitorIndex.test.js`, cancel waiting for asynchronous actions as the assertion result is not affected with or without it.
4. Add an `async` mark of a test in `WhereExpression.test.js` to eliminate the following console error:
![Snipaste_2021-01-20_23-52-55 console error](https://user-images.githubusercontent.com/62041081/105393381-1c898880-5bd1-11eb-9aa1-f8e055527ada.png)
5. Update jest snapshot files.

**Note:**
There will be plenty of `console.warn` in both unit tests and browser according to [Formik v2 migration guide](https://formik.org/docs/migrating-v2#all-render-props-have-been-deprecated-with-a-console-warning).
I will address it in another PR as lots of files are involved.
![Snipaste_2021-01-21_11-39-23 console warn render](https://user-images.githubusercontent.com/62041081/105403320-73955a80-5bdd-11eb-937a-c2e7b2c59f36.png)

**Test results:**
Unit test:
```
Test Suites: 6 skipped, 83 passed, 83 of 89 total
Tests:       20 skipped, 385 passed, 405 total
Snapshots:   4 updated, 131 passed, 135 total
Time:        45.271 s
Ran all test suites.
✨  Done in 46.40s.
```
End-to-End test:
```
       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  alert_spec.js                            02:46        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  destination_spec.js                      00:33        4        4        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  monitor_spec.js                          00:47        6        6        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        04:07       15       15        -        -        -  

✨  Done in 286.14s.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
