### PR TITLE
Fix e2e test failure when by setting security tenant when visiting Kibana

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -50,6 +50,8 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
     } else {
       options = { auth: ADMIN_AUTH };
     }
+    // Add query parameters - select the default Kibana tenant
+    options.qs = { security_tenant: 'private' };
     return originalFn(url, options);
   } else {
     return originalFn(url, options);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/600

The E2E test fails due to the "select your tenant" modal shows up when a user visits Kibana for the first time, and probably because of a change in security plugin in ODFE 1.13.
<img width="997" alt="select your tenant - modal 7 10 2" src="https://user-images.githubusercontent.com/78394866/108813414-d758cd80-7565-11eb-91ad-1b2c38d5c28b.png">

The modal will disappear if user click any button ("close", "cancel", or "confirm"), or refresh the page.

*Description of changes:*

- Add `security_tenant='private'` in the URL parameter of the HTTP request for visiting Kibana.
The the full request will be like: `http://localhost:5601/app/home?security_tenant='private'`

**Explanation**:
From the [code](https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/blob/090c2dc78b65c523ae325a40a55e883c425f706c/server/multitenancy/tenant_resolver.ts#L37) in " opendistro-for-elasticsearch/security-kibana-plugin" repository, The `security_tenant` can be either put in the HTTP request header or the URL parameter.

I chose to put into the URL query parameter, because it didn't work for me to put into the header through Cypress.

According to the [document](https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/multi-tenancy/), all users at least have access to 2 tenants: "Private" and "Global". "Private" is the default for "Security Kibana Plugin", so I set it in the test.

**Testing**:
Started an ODFE cluster through Docker image, and ran `yarn run cypress run --env security_enabled=ture`
```
       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  alert_spec.js                            02:23        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  destination_spec.js                      00:23        4        4        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  monitor_spec.js                          00:28        6        6        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        03:15       15       15        -        -        -  

✨  Done in 228.90s.
```

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.