### PR TITLE
Local uri input monitor support

### DIFF
--- a/public/pages/CreateMonitor/components/LocalUriInput/LocalUriInput.js
+++ b/public/pages/CreateMonitor/components/LocalUriInput/LocalUriInput.js
@@ -16,29 +16,28 @@
 import React, { Fragment } from 'react';
 import { EuiSpacer, EuiFlexItem, EuiFlexGroup, EuiCodeEditor, EuiFormRow } from '@elastic/eui';
 import FormikSelect from '../../../../components/FormControls/FormikSelect';
-
-const supportedClusterApis = [
-  { value: '', text: '' },
-  { value: '/_cluster/health', text: 'Define using ClusterHealth endpoint' },
-  { value: '/_cluster/stats', text: 'Define using ClusterStats endpoint' },
-];
+import { hasError, isInvalid } from '../../../../utils/validate';
+import { FormikFieldText } from '../../../../components/FormControls';
 
 const LocalUriInput = ({ isDarkMode, response, values }) => (
   <Fragment>
     <EuiFlexGroup alignItems="flexStart">
       <EuiFlexItem>
         <EuiSpacer size="m" />
-        <FormikSelect
-          name={`${values.searchType}.apiType`}
+        <FormikFieldText
+          name={`${values.searchType}.path`}
           formRow
           rowProps={{
-            label: 'Select API',
+            label: 'Path',
+            helpText: 'Example path: "/_cluster/health/"',
             style: { paddingLeft: '10px' },
+            isInvalid,
+            error: hasError,
           }}
           inputProps={{
-            options: supportedClusterApis,
+            isInvalid,
             onChange: (e, field, form) => {
-              form.setFieldValue('apiType', e.target.value);
+              form.setFieldValue('uri.path', e.target.value);
             },
           }}
         />

--- a/public/pages/CreateMonitor/components/LocalUriInput/LocalUriInput.js
+++ b/public/pages/CreateMonitor/components/LocalUriInput/LocalUriInput.js
@@ -15,7 +15,6 @@
 
 import React, { Fragment } from 'react';
 import { EuiSpacer, EuiFlexItem, EuiFlexGroup, EuiCodeEditor, EuiFormRow } from '@elastic/eui';
-import FormikSelect from '../../../../components/FormControls/FormikSelect';
 import { hasError, isInvalid } from '../../../../utils/validate';
 import { FormikFieldText } from '../../../../components/FormControls';
 

--- a/public/pages/CreateMonitor/components/LocalUriInput/LocalUriInput.js
+++ b/public/pages/CreateMonitor/components/LocalUriInput/LocalUriInput.js
@@ -1,0 +1,62 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React, { Fragment } from 'react';
+import { EuiSpacer, EuiFlexItem, EuiFlexGroup, EuiCodeEditor, EuiFormRow } from '@elastic/eui';
+import FormikSelect from '../../../../components/FormControls/FormikSelect';
+
+const supportedClusterApis = [
+  { value: '', text: '' },
+  { value: '/_cluster/health', text: 'Define using ClusterHealth endpoint' },
+  { value: '/_cluster/stats', text: 'Define using ClusterStats endpoint' },
+];
+
+const LocalUriInput = ({ isDarkMode, response, values }) => (
+  <Fragment>
+    <EuiFlexGroup alignItems="flexStart">
+      <EuiFlexItem>
+        <EuiSpacer size="m" />
+        <FormikSelect
+          name={`${values.searchType}.apiType`}
+          formRow
+          rowProps={{
+            label: 'Select API',
+            style: { paddingLeft: '10px' },
+          }}
+          inputProps={{
+            options: supportedClusterApis,
+            onChange: (e, field, form) => {
+              form.setFieldValue('apiType', e.target.value);
+            },
+          }}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFormRow label="Response" fullWidth>
+          <EuiCodeEditor
+            mode="json"
+            theme={isDarkMode ? 'sense-dark' : 'github'}
+            width="100%"
+            height="500px"
+            value={response}
+            readOnly
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </Fragment>
+);
+
+export default LocalUriInput;

--- a/public/pages/CreateMonitor/components/LocalUriInput/LocalUriInput.test.js
+++ b/public/pages/CreateMonitor/components/LocalUriInput/LocalUriInput.test.js
@@ -12,12 +12,19 @@
  *   express or implied. See the License for the specific language governing
  *   permissions and limitations under the License.
  */
+import React from 'react';
+import { render } from 'enzyme';
+import { Formik } from 'formik';
 
-export function buildLocalUriRequest(values) {
-  return {
-    scheme: 'http',
-    host: '127.0.0.1',
-    port: '9200',
-    path: values.uri.path,
-  };
-}
+import LocalUriInput from './LocalUriInput';
+
+describe('LocalUriInput', () => {
+  test('renders', () => {
+    const component = (
+      <Formik>
+        <LocalUriInput values={{ searchType: 'localUri' }} />
+      </Formik>
+    );
+    expect(render(component)).toMatchSnapshot();
+  });
+});

--- a/public/pages/CreateMonitor/components/LocalUriInput/__snapshots__/LocalUriInput.test.js.snap
+++ b/public/pages/CreateMonitor/components/LocalUriInput/__snapshots__/LocalUriInput.test.js.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LocalUriInput renders 1`] = `
+<div
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--directionRow euiFlexGroup--responsive"
+>
+  <div
+    class="euiFlexItem"
+  >
+    <div
+      class="euiSpacer euiSpacer--m"
+    />
+    <div
+      class="euiFormRow"
+      id="localUri.path-form-row-row"
+      style="padding-left:10px"
+    >
+      <div
+        class="euiFormRow__labelWrapper"
+      >
+        <label
+          aria-invalid="false"
+          class="euiFormLabel euiFormRow__label"
+          for="localUri.path-form-row"
+        >
+          Path
+        </label>
+      </div>
+      <div
+        class="euiFormRow__fieldWrapper"
+      >
+        <div
+          class="euiFormControlLayout"
+        >
+          <div
+            class="euiFormControlLayout__childrenWrapper"
+          >
+            <input
+              class="euiFieldText"
+              name="localUri.path"
+              type="text"
+            />
+          </div>
+        </div>
+        <div
+          class="euiFormHelpText euiFormRow__text"
+          id="localUri.path-form-row-help"
+        >
+          Example path: "/_cluster/health/"
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFlexItem"
+  >
+    <div
+      class="euiFormRow euiFormRow--fullWidth"
+      id="generated-id-row"
+    >
+      <div
+        class="euiFormRow__labelWrapper"
+      >
+        <label
+          class="euiFormLabel euiFormRow__label"
+          for="generated-id"
+        >
+          Response
+        </label>
+      </div>
+      <div
+        class="euiFormRow__fieldWrapper"
+      >
+        <div
+          class="euiCodeEditorWrapper"
+          data-test-subj="codeEditorContainer"
+          style="width:100%;height:500px"
+        >
+          <div
+            class="euiCodeEditorKeyboardHint"
+            data-test-subj="codeEditorHint"
+            id="generated-id"
+            role="button"
+            tabindex="0"
+          >
+            <p
+              class="euiText"
+            >
+              Press Enter to start editing.
+            </p>
+            <p
+              class="euiText"
+            >
+              When you're done, press Escape to stop editing.
+            </p>
+          </div>
+          <div
+            id="generated-id"
+            style="width:100%;height:500px"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/public/pages/CreateMonitor/components/LocalUriInput/index.js
+++ b/public/pages/CreateMonitor/components/LocalUriInput/index.js
@@ -1,0 +1,18 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import LocalUriImport from './LocalUriInput';
+
+export default LocalUriImport;

--- a/public/pages/CreateMonitor/components/MonitorDefinition/MonitorDefinition.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinition/MonitorDefinition.js
@@ -20,7 +20,7 @@ import { ES_AD_PLUGIN } from '../../../../utils/constants';
 const defaultSelectDefinitions = [
   { value: 'graph', text: 'Define using visual graph' },
   { value: 'query', text: 'Define using extraction query' },
-  { value: 'clusterApi', text: 'Define using Cluster API endpoint' },
+  { value: 'localUri', text: 'Define using Local URI endpoint' },
 ];
 
 const onChangeDefinition = (e, form, resetResponse) => {

--- a/public/pages/CreateMonitor/components/MonitorDefinition/MonitorDefinition.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinition/MonitorDefinition.js
@@ -20,6 +20,7 @@ import { ES_AD_PLUGIN } from '../../../../utils/constants';
 const defaultSelectDefinitions = [
   { value: 'graph', text: 'Define using visual graph' },
   { value: 'query', text: 'Define using extraction query' },
+  { value: 'clusterApi', text: 'Define using Cluster API endpoint' },
 ];
 
 const onChangeDefinition = (e, form, resetResponse) => {
@@ -28,7 +29,7 @@ const onChangeDefinition = (e, form, resetResponse) => {
   form.setFieldValue('searchType', type);
 };
 
-const selectDefinitions = plugins => {
+const selectDefinitions = (plugins) => {
   return plugins === undefined || plugins.indexOf(ES_AD_PLUGIN) == -1
     ? defaultSelectDefinitions
     : [...defaultSelectDefinitions, { value: 'ad', text: 'Define using anomaly detector' }];

--- a/public/pages/CreateMonitor/components/MonitorDefinition/__snapshots__/MonitorDefinition.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorDefinition/__snapshots__/MonitorDefinition.test.js.snap
@@ -40,6 +40,11 @@ exports[`MonitorDefinition renders 1`] = `
           >
             Define using extraction query
           </option>
+          <option
+            value="localUri"
+          >
+            Define using Local URI endpoint
+          </option>
         </select>
         <div
           class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/__snapshots__/AnomalyDetector.test.js.snap
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/__snapshots__/AnomalyDetector.test.js.snap
@@ -35,6 +35,13 @@ exports[`AnomalyDetectors renders 1`] = `
       "searchType": "graph",
       "timeField": "",
       "timezone": Array [],
+      "uri": Object {
+        "host": "localhost",
+        "path": "",
+        "port": "9200",
+        "scheme": "http",
+        "url": "",
+      },
       "weekly": Object {
         "fri": false,
         "mon": false,
@@ -89,6 +96,13 @@ exports[`AnomalyDetectors renders 1`] = `
         "searchType": "graph",
         "timeField": "",
         "timezone": Array [],
+        "uri": Object {
+          "host": "localhost",
+          "path": "",
+          "port": "9200",
+          "scheme": "http",
+          "url": "",
+        },
         "weekly": Object {
           "fri": false,
           "mon": false,
@@ -204,6 +218,13 @@ exports[`AnomalyDetectors renders 1`] = `
                     "searchType": "graph",
                     "timeField": "",
                     "timezone": Array [],
+                    "uri": Object {
+                      "host": "localhost",
+                      "path": "",
+                      "port": "9200",
+                      "scheme": "http",
+                      "url": "",
+                    },
                     "weekly": Object {
                       "fri": false,
                       "mon": false,
@@ -277,6 +298,13 @@ exports[`AnomalyDetectors renders 1`] = `
                     "searchType": "graph",
                     "timeField": "",
                     "timezone": Array [],
+                    "uri": Object {
+                      "host": "localhost",
+                      "path": "",
+                      "port": "9200",
+                      "scheme": "http",
+                      "url": "",
+                    },
                     "weekly": Object {
                       "fri": false,
                       "mon": false,
@@ -398,6 +426,13 @@ exports[`AnomalyDetectors renders 1`] = `
                             "searchType": "graph",
                             "timeField": "",
                             "timezone": Array [],
+                            "uri": Object {
+                              "host": "localhost",
+                              "path": "",
+                              "port": "9200",
+                              "scheme": "http",
+                              "url": "",
+                            },
                             "weekly": Object {
                               "fri": false,
                               "mon": false,
@@ -471,6 +506,13 @@ exports[`AnomalyDetectors renders 1`] = `
                             "searchType": "graph",
                             "timeField": "",
                             "timezone": Array [],
+                            "uri": Object {
+                              "host": "localhost",
+                              "path": "",
+                              "port": "9200",
+                              "scheme": "http",
+                              "url": "",
+                            },
                             "weekly": Object {
                               "fri": false,
                               "mon": false,

--- a/public/pages/CreateMonitor/containers/CreateMonitor/__snapshots__/CreateMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/__snapshots__/CreateMonitor.test.js.snap
@@ -42,6 +42,13 @@ exports[`CreateMonitor renders 1`] = `
         "searchType": "graph",
         "timeField": "",
         "timezone": Array [],
+        "uri": Object {
+          "host": "localhost",
+          "path": "",
+          "port": "9200",
+          "scheme": "http",
+          "url": "",
+        },
         "weekly": Object {
           "fri": false,
           "mon": false,

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/__snapshots__/formikToMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/__snapshots__/formikToMonitor.test.js.snap
@@ -91,6 +91,28 @@ Array [
 ]
 `;
 
+exports[`formikToInputs can call formikToLocalUri 1`] = `
+Object {
+  "uri": Object {
+    "host": "localhost",
+    "path": "",
+    "port": "9200",
+    "scheme": "http",
+  },
+}
+`;
+
+exports[`formikToLocalUri can build a LocalUriInput request 1`] = `
+Object {
+  "uri": Object {
+    "host": "localhost",
+    "path": "",
+    "port": "9200",
+    "scheme": "http",
+  },
+}
+`;
+
 exports[`formikToMonitor can build monitor 1`] = `
 Object {
   "enabled": false,

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
@@ -33,6 +33,14 @@ export const FORMIK_INITIAL_VALUES = {
 
   /* DEFINE MONITOR */
   searchType: 'graph',
+  apiType: '',
+  uri: {
+    scheme: 'http',
+    host: '127.0.0.1',
+    port: '9200',
+    path: '',
+    url: '',
+  },
   index: [],
   timeField: '',
   query: MATCH_ALL_QUERY,

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
@@ -33,11 +33,9 @@ export const FORMIK_INITIAL_VALUES = {
 
   /* DEFINE MONITOR */
   searchType: 'graph',
-  path: '',
-  apiType: '',
   uri: {
     scheme: 'http',
-    host: '127.0.0.1',
+    host: 'localhost',
     port: '9200',
     path: '',
     url: '',

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
@@ -33,6 +33,7 @@ export const FORMIK_INITIAL_VALUES = {
 
   /* DEFINE MONITOR */
   searchType: 'graph',
+  path: '',
   apiType: '',
   uri: {
     scheme: 'http',

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
@@ -41,7 +41,7 @@ export function formikToInputs(values) {
   switch (values.searchType) {
     case SEARCH_TYPE.AD:
       return formikToAd(values);
-    case SEARCH_TYPE.CLUSTER_API:
+    case SEARCH_TYPE.LOCAL_URI:
       return formikToLocalUri(values);
     default:
       return formikToSearch(values);
@@ -112,7 +112,7 @@ export function formikToLocalUri(values) {
       scheme: 'http',
       host: 'localhost',
       port: '9200',
-      path: values.apiType,
+      path: values.apiType ? values.apiType : values.uri.path,
     },
   };
 }

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
@@ -112,7 +112,7 @@ export function formikToLocalUri(values) {
       scheme: 'http',
       host: 'localhost',
       port: '9200',
-      path: values.apiType ? values.apiType : values.uri.path,
+      path: values.uri.path,
     },
   };
 }

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
@@ -28,7 +28,7 @@ export function formikToMonitor(values) {
     type: 'monitor',
     enabled: !values.disabled,
     schedule,
-    inputs: [formikToSearch(values)],
+    inputs: [formikToInputs(values)],
     triggers: [],
     ui_metadata: {
       schedule: uiSchedule,
@@ -38,8 +38,14 @@ export function formikToMonitor(values) {
 }
 
 export function formikToInputs(values) {
-  const isAD = values.searchType === SEARCH_TYPE.AD;
-  return [isAD ? formikToAd(values) : formikToSearch(values)];
+  switch (values.searchType) {
+    case SEARCH_TYPE.AD:
+      return formikToAd(values);
+    case SEARCH_TYPE.CLUSTER_API:
+      return formikToLocalUri(values);
+    default:
+      return formikToSearch(values);
+  }
 }
 
 export function formikToSearch(values) {
@@ -99,6 +105,18 @@ export function formikToAd(values) {
     },
   };
 }
+
+export function formikToLocalUri(values) {
+  return {
+    uri: {
+      scheme: 'http',
+      host: 'localhost',
+      port: '9200',
+      path: values.apiType,
+    },
+  };
+}
+
 export function formikToUiSearch(values) {
   const {
     searchType,

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.test.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.test.js
@@ -28,6 +28,8 @@ import {
   buildSchedule,
   formikToWhereClause,
   formikToAd,
+  formikToInputs,
+  formikToLocalUri,
 } from './formikToMonitor';
 
 import { FORMIK_INITIAL_VALUES } from './constants';
@@ -51,11 +53,26 @@ describe('formikToMonitor', () => {
   });
 });
 
+describe('formikToInputs', () => {
+  const formikValues = _.cloneDeep(FORMIK_INITIAL_VALUES);
+  test('can call formikToLocalUri', () => {
+    formikValues.searchType = 'localUri';
+    expect(formikToInputs(formikValues)).toMatchSnapshot();
+  });
+});
+
 describe('formikToDetector', () => {
   const formikValues = _.cloneDeep(FORMIK_INITIAL_VALUES);
   formikValues.detectorId = 'temp_detector';
   test('can build detector', () => {
     expect(formikToAd(formikValues)).toMatchSnapshot();
+  });
+});
+
+describe('formikToLocalUri', () => {
+  test('can build a LocalUriInput request', () => {
+    const formikValues = _.cloneDeep(FORMIK_INITIAL_VALUES);
+    expect(formikToLocalUri(formikValues)).toMatchSnapshot();
   });
 });
 

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
@@ -35,8 +35,6 @@ export default function monitorToFormik(monitor) {
 
   function inputsToFormik() {
     if (searchType === SEARCH_TYPE.LOCAL_URI) {
-      console.log('HURNEYT: monitorToFormik inputsToFormik inputs = ' + JSON.stringify(inputs));
-      console.log('HURNEYT: monitorToFormik inputsToFormik uri = ' + JSON.stringify(inputs[0].uri));
       return {
         uri: inputs[0].uri,
       };

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
@@ -31,10 +31,10 @@ export default function monitorToFormik(monitor) {
   // Default searchType to query, because if there is no ui_metadata or search then it was created through API or overwritten by API
   // In that case we don't want to guess on the UI what selections a user made, so we will default to just showing the extraction query
   let { searchType = 'query', fieldName } = search;
-  if (_.isEmpty(search) && 'uri' in inputs[0]) searchType = SEARCH_TYPE.CLUSTER_API;
+  if (_.isEmpty(search) && 'uri' in inputs[0]) searchType = SEARCH_TYPE.LOCAL_URI;
 
   function inputsToFormik() {
-    if (searchType === SEARCH_TYPE.CLUSTER_API) {
+    if (searchType === SEARCH_TYPE.LOCAL_URI) {
       console.log('HURNEYT: monitorToFormik inputsToFormik inputs = ' + JSON.stringify(inputs));
       console.log('HURNEYT: monitorToFormik inputsToFormik uri = ' + JSON.stringify(inputs[0].uri));
       return {

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
@@ -30,8 +30,35 @@ export default function monitorToFormik(monitor) {
   } = monitor;
   // Default searchType to query, because if there is no ui_metadata or search then it was created through API or overwritten by API
   // In that case we don't want to guess on the UI what selections a user made, so we will default to just showing the extraction query
-  const { searchType = 'query', fieldName } = search;
-  const isAD = searchType === SEARCH_TYPE.AD;
+  let { searchType = 'query', fieldName } = search;
+  if (_.isEmpty(search) && 'uri' in inputs[0]) searchType = SEARCH_TYPE.CLUSTER_API;
+
+  function inputsToFormik() {
+    if (searchType === SEARCH_TYPE.CLUSTER_API) {
+      console.log('HURNEYT: monitorToFormik inputsToFormik inputs = ' + JSON.stringify(inputs));
+      console.log('HURNEYT: monitorToFormik inputsToFormik uri = ' + JSON.stringify(inputs[0].uri));
+      return {
+        uri: inputs[0].uri,
+      };
+    } else {
+      const {
+        search: { indices, query },
+      } = inputs[0];
+      if (searchType === SEARCH_TYPE.AD) {
+        return {
+          detectorId: _.get(inputs, INPUTS_DETECTOR_ID),
+          index: indices.map((index) => ({ label: index })),
+          query: JSON.stringify(query, null, 4),
+        };
+      } else {
+        // when searchType is Query or Graph
+        return {
+          index: indices.map((index) => ({ label: index })),
+          query: JSON.stringify(query, null, 4),
+        };
+      }
+    }
+  }
 
   return {
     /* INITIALIZE WITH DEFAULTS */
@@ -51,8 +78,6 @@ export default function monitorToFormik(monitor) {
     fieldName: fieldName ? [{ label: fieldName }] : [],
     timezone: timezone ? [{ label: timezone }] : [],
 
-    detectorId: isAD ? _.get(inputs, INPUTS_DETECTOR_ID) : undefined,
-    index: inputs[0].search.indices.map(index => ({ label: index })),
-    query: JSON.stringify(inputs[0].search.query, null, 4),
+    ...inputsToFormik(),
   };
 }

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.test.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.test.js
@@ -90,7 +90,7 @@ describe('monitorToFormik', () => {
         JSON.stringify(exampleMonitor.inputs[0].search.query, null, 4)
       );
       expect(formikValues.index).toEqual(
-        exampleMonitor.inputs[0].search.indices.map(index => ({ label: index }))
+        exampleMonitor.inputs[0].search.indices.map((index) => ({ label: index }))
       );
     });
 
@@ -160,5 +160,19 @@ describe('monitorToFormik', () => {
       expect(formikValues.detectorId).toBe('zIqG0nABwoJjo1UZKHnL');
       expect(formikValues.query).toContain('zIqG0nABwoJjo1UZKHnL');
     });
+  });
+
+  test('can build LocalUriInput monitor', () => {
+    const localUriMonitor = _.cloneDeep(exampleMonitor);
+    localUriMonitor.ui_metadata.search.searchType = 'localUri';
+    localUriMonitor.inputs = [
+      {
+        uri: {
+          path: '/_cluster/health',
+        },
+      },
+    ];
+    const formikValues = monitorToFormik(localUriMonitor);
+    expect(formikValues.uri.path).toBe('/_cluster/health');
   });
 });

--- a/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
@@ -171,8 +171,6 @@ class DefineMonitor extends Component {
     const { httpClient, values, notifications } = this.props;
     const formikSnapshot = _.cloneDeep(values);
 
-    console.log('HURNEYT: Starting onRunQuery');
-
     // If we are running a visual graph query, then we need to run two separate queries
     // 1. The actual query that will be saved on the monitor, to get accurate query performance stats
     // 2. The UI generated query that gets [BUCKET_COUNT] times the aggregated buckets to show past history of query
@@ -181,7 +179,6 @@ class DefineMonitor extends Component {
     let requests;
     switch (searchType) {
       case SEARCH_TYPE.QUERY:
-        console.log('HURNEYT: Starting onRunQuery - query check');
         requests = [buildSearchRequest(values)];
         break;
       case SEARCH_TYPE.GRAPH:
@@ -189,14 +186,11 @@ class DefineMonitor extends Component {
         // 1. The actual query that will be saved on the monitor, to get accurate query performance stats
         // 2. The UI generated query that gets [BUCKET_COUNT] times the aggregated buckets to show past history of query
         // If the query is an extraction query, we can use the same query for results and query performance
-        console.log('HURNEYT: Starting onRunQuery - graph check');
         requests = [buildSearchRequest(values)];
         requests.push(buildSearchRequest(values, false));
         break;
       case SEARCH_TYPE.LOCAL_URI:
-        console.log('HURNEYT: Starting onRunQuery - buildLocalUriRequest');
         requests = [buildLocalUriRequest(values)];
-        console.log('HURNEYT: Finishing onRunQuery - buildLocalUriRequest');
         break;
     }
 
@@ -206,28 +200,19 @@ class DefineMonitor extends Component {
         // Set triggers to empty array so they are not executed (if in edit workflow)
         // Set input search to query/graph query and then use execute API to fill in period_start/period_end
         const monitor = formikToMonitor(values);
-        console.log('HURNEYT: values.apiType - ' + values.apiType);
-        console.log('HURNEYT: monitor - ' + JSON.stringify(monitor.inputs[0].search));
         _.set(monitor, 'name', 'TEMP_MONITOR');
         _.set(monitor, 'triggers', []);
         if (searchType === SEARCH_TYPE.QUERY || searchType === SEARCH_TYPE.GRAPH) {
-          console.log('HURNEYT: Starting onRunQuery - monitor query or graph check');
           _.set(monitor, 'inputs[0].search', request);
         } else if (searchType === SEARCH_TYPE.LOCAL_URI) {
-          console.log('HURNEYT: Starting onRunQuery - monitor API check');
           _.set(monitor, 'inputs[0].uri', request);
         }
-        console.log('HURNEYT: Starting onRunQuery - httpClient.post');
-        console.log('HURNEYT: requests JSON - ' + JSON.stringify(monitor));
         return httpClient.post('../api/alerting/monitors/_execute', {
           body: JSON.stringify(monitor),
         });
       });
-      console.log('HURNEYT: Finishing onRunQuery - httpClient.post');
 
       const [queryResponse, optionalResponse] = await Promise.all(promises);
-
-      console.log('HURNEYT: DefineMonitor queryResponse = ' + JSON.stringify(queryResponse));
 
       if (queryResponse.ok) {
         const response = _.get(queryResponse.resp, 'input_results.results[0]');
@@ -361,9 +346,7 @@ class DefineMonitor extends Component {
     const { values } = this.props;
     const { response } = this.state;
     // Definition of when the "run" button should be disabled for LocalUri type.
-    console.log('HURNEYT: DefineMonitor renderLocalUriInput = ' + values.uri.path);
     const runIsDisabled = !values.uri.path;
-    console.log('HURNEYT: DefineMonitor runIsDisabled = ' + runIsDisabled);
     return {
       actions: [
         <EuiButton disabled={runIsDisabled} onClick={this.onRunQuery}>

--- a/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
@@ -193,7 +193,7 @@ class DefineMonitor extends Component {
         requests = [buildSearchRequest(values)];
         requests.push(buildSearchRequest(values, false));
         break;
-      case SEARCH_TYPE.CLUSTER_API:
+      case SEARCH_TYPE.LOCAL_URI:
         console.log('HURNEYT: Starting onRunQuery - buildLocalUriRequest');
         requests = [buildLocalUriRequest(values)];
         console.log('HURNEYT: Finishing onRunQuery - buildLocalUriRequest');
@@ -213,7 +213,7 @@ class DefineMonitor extends Component {
         if (searchType === SEARCH_TYPE.QUERY || searchType === SEARCH_TYPE.GRAPH) {
           console.log('HURNEYT: Starting onRunQuery - monitor query or graph check');
           _.set(monitor, 'inputs[0].search', request);
-        } else if (searchType === SEARCH_TYPE.CLUSTER_API) {
+        } else if (searchType === SEARCH_TYPE.LOCAL_URI) {
           console.log('HURNEYT: Starting onRunQuery - monitor API check');
           _.set(monitor, 'inputs[0].uri', request);
         }
@@ -361,8 +361,8 @@ class DefineMonitor extends Component {
     const { values } = this.props;
     const { response } = this.state;
     // Definition of when the "run" button should be disabled for LocalUri type.
-    console.log('HURNEYT: DefineMonitor renderLocalUriInput = ' + values.apiType);
-    const runIsDisabled = !values.apiType;
+    console.log('HURNEYT: DefineMonitor renderLocalUriInput = ' + values.uri.path);
+    const runIsDisabled = !values.uri.path;
     console.log('HURNEYT: DefineMonitor runIsDisabled = ' + runIsDisabled);
     return {
       actions: [
@@ -389,7 +389,7 @@ class DefineMonitor extends Component {
         return this.renderAnomalyDetector();
       case SEARCH_TYPE.GRAPH:
         return this.renderVisualMonitor();
-      case SEARCH_TYPE.CLUSTER_API:
+      case SEARCH_TYPE.LOCAL_URI:
         return this.renderLocalUriInput();
       default:
         return this.renderExtractionQuery();

--- a/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
@@ -31,6 +31,8 @@ import { buildSearchRequest } from './utils/searchRequests';
 import { SEARCH_TYPE, ES_AD_PLUGIN } from '../../../../utils/constants';
 import AnomalyDetectors from '../AnomalyDetectors/AnomalyDetectors';
 import { backendErrorNotification } from '../../../../utils/helpers';
+import LocalUriInput from '../../components/LocalUriInput';
+import { buildLocalUriRequest } from './utils/localUriRequests';
 
 function renderEmptyMessage(message) {
   return (
@@ -74,6 +76,7 @@ class DefineMonitor extends Component {
     this.renderVisualMonitor = this.renderVisualMonitor.bind(this);
     this.renderExtractionQuery = this.renderExtractionQuery.bind(this);
     this.renderAnomalyDetector = this.renderAnomalyDetector.bind(this);
+    this.renderLocalUriInput = this.renderLocalUriInput.bind(this);
     this.getMonitorContent = this.getMonitorContent.bind(this);
     this.getPlugins = this.getPlugins.bind(this);
     this.showPluginWarning = this.showPluginWarning.bind(this);
@@ -168,30 +171,63 @@ class DefineMonitor extends Component {
     const { httpClient, values, notifications } = this.props;
     const formikSnapshot = _.cloneDeep(values);
 
+    console.log('HURNEYT: Starting onRunQuery');
+
     // If we are running a visual graph query, then we need to run two separate queries
     // 1. The actual query that will be saved on the monitor, to get accurate query performance stats
     // 2. The UI generated query that gets [BUCKET_COUNT] times the aggregated buckets to show past history of query
     // If the query is an extraction query, we can use the same query for results and query performance
-    const searchRequests = [buildSearchRequest(values)];
-    if (values.searchType === SEARCH_TYPE.GRAPH) {
-      searchRequests.push(buildSearchRequest(values, false));
+    const searchType = values.searchType;
+    let requests;
+    switch (searchType) {
+      case SEARCH_TYPE.QUERY:
+        console.log('HURNEYT: Starting onRunQuery - query check');
+        requests = [buildSearchRequest(values)];
+        break;
+      case SEARCH_TYPE.GRAPH:
+        // If we are running a visual graph query, then we need to run two separate queries
+        // 1. The actual query that will be saved on the monitor, to get accurate query performance stats
+        // 2. The UI generated query that gets [BUCKET_COUNT] times the aggregated buckets to show past history of query
+        // If the query is an extraction query, we can use the same query for results and query performance
+        console.log('HURNEYT: Starting onRunQuery - graph check');
+        requests = [buildSearchRequest(values)];
+        requests.push(buildSearchRequest(values, false));
+        break;
+      case SEARCH_TYPE.CLUSTER_API:
+        console.log('HURNEYT: Starting onRunQuery - buildLocalUriRequest');
+        requests = [buildLocalUriRequest(values)];
+        console.log('HURNEYT: Finishing onRunQuery - buildLocalUriRequest');
+        break;
     }
 
     try {
-      const promises = searchRequests.map((searchRequest) => {
+      const promises = requests.map((request) => {
         // Fill in monitor name in case it's empty (in create workflow)
         // Set triggers to empty array so they are not executed (if in edit workflow)
         // Set input search to query/graph query and then use execute API to fill in period_start/period_end
         const monitor = formikToMonitor(values);
+        console.log('HURNEYT: values.apiType - ' + values.apiType);
+        console.log('HURNEYT: monitor - ' + JSON.stringify(monitor.inputs[0].search));
         _.set(monitor, 'name', 'TEMP_MONITOR');
         _.set(monitor, 'triggers', []);
-        _.set(monitor, 'inputs[0].search', searchRequest);
+        if (searchType === SEARCH_TYPE.QUERY || searchType === SEARCH_TYPE.GRAPH) {
+          console.log('HURNEYT: Starting onRunQuery - monitor query or graph check');
+          _.set(monitor, 'inputs[0].search', request);
+        } else if (searchType === SEARCH_TYPE.CLUSTER_API) {
+          console.log('HURNEYT: Starting onRunQuery - monitor API check');
+          _.set(monitor, 'inputs[0].uri', request);
+        }
+        console.log('HURNEYT: Starting onRunQuery - httpClient.post');
+        console.log('HURNEYT: requests JSON - ' + JSON.stringify(monitor));
         return httpClient.post('../api/alerting/monitors/_execute', {
           body: JSON.stringify(monitor),
         });
       });
+      console.log('HURNEYT: Finishing onRunQuery - httpClient.post');
 
       const [queryResponse, optionalResponse] = await Promise.all(promises);
+
+      console.log('HURNEYT: DefineMonitor queryResponse = ' + JSON.stringify(queryResponse));
 
       if (queryResponse.ok) {
         const response = _.get(queryResponse.resp, 'input_results.results[0]');
@@ -321,6 +357,31 @@ class DefineMonitor extends Component {
     };
   }
 
+  renderLocalUriInput() {
+    const { values } = this.props;
+    const { response } = this.state;
+    // Definition of when the "run" button should be disabled for LocalUri type.
+    console.log('HURNEYT: DefineMonitor renderLocalUriInput = ' + values.apiType);
+    const runIsDisabled = !values.apiType;
+    console.log('HURNEYT: DefineMonitor runIsDisabled = ' + runIsDisabled);
+    return {
+      actions: [
+        <EuiButton disabled={runIsDisabled} onClick={this.onRunQuery}>
+          Run
+        </EuiButton>,
+      ],
+      content: (
+        <React.Fragment>
+          <LocalUriInput
+            response={JSON.stringify(response || '', null, 4)}
+            isDarkMode={this.isDarkMode}
+            values={values}
+          />
+        </React.Fragment>
+      ),
+    };
+  }
+
   getMonitorContent() {
     const { values } = this.props;
     switch (values.searchType) {
@@ -328,6 +389,8 @@ class DefineMonitor extends Component {
         return this.renderAnomalyDetector();
       case SEARCH_TYPE.GRAPH:
         return this.renderVisualMonitor();
+      case SEARCH_TYPE.CLUSTER_API:
+        return this.renderLocalUriInput();
       default:
         return this.renderExtractionQuery();
     }

--- a/public/pages/CreateMonitor/containers/DefineMonitor/__snapshots__/DefineMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/__snapshots__/DefineMonitor.test.js.snap
@@ -129,6 +129,13 @@ exports[`DefineMonitor should show warning in case of Ad monitor and plugin is n
           "searchType": "ad",
           "timeField": "",
           "timezone": Array [],
+          "uri": Object {
+            "host": "localhost",
+            "path": "",
+            "port": "9200",
+            "scheme": "http",
+            "url": "",
+          },
           "weekly": Object {
             "fri": false,
             "mon": false,

--- a/public/pages/CreateMonitor/containers/DefineMonitor/utils/localUriRequests.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/utils/localUriRequests.js
@@ -1,0 +1,23 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+export function buildLocalUriRequest(values) {
+  return {
+    scheme: 'http',
+    host: '127.0.0.1',
+    port: '9200',
+    path: values.apiType ? values.apiType : values.uri.path,
+  };
+}

--- a/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
@@ -35,6 +35,13 @@ exports[`MonitorIndex renders 1`] = `
       "searchType": "graph",
       "timeField": "",
       "timezone": Array [],
+      "uri": Object {
+        "host": "localhost",
+        "path": "",
+        "port": "9200",
+        "scheme": "http",
+        "url": "",
+      },
       "weekly": Object {
         "fri": false,
         "mon": false,
@@ -161,6 +168,13 @@ exports[`MonitorIndex renders 1`] = `
                   "searchType": "graph",
                   "timeField": "",
                   "timezone": Array [],
+                  "uri": Object {
+                    "host": "localhost",
+                    "path": "",
+                    "port": "9200",
+                    "scheme": "http",
+                    "url": "",
+                  },
                   "weekly": Object {
                     "fri": false,
                     "mon": false,
@@ -234,6 +248,13 @@ exports[`MonitorIndex renders 1`] = `
                   "searchType": "graph",
                   "timeField": "",
                   "timezone": Array [],
+                  "uri": Object {
+                    "host": "localhost",
+                    "path": "",
+                    "port": "9200",
+                    "scheme": "http",
+                    "url": "",
+                  },
                   "weekly": Object {
                     "fri": false,
                     "mon": false,
@@ -371,6 +392,13 @@ exports[`MonitorIndex renders 1`] = `
                           "searchType": "graph",
                           "timeField": "",
                           "timezone": Array [],
+                          "uri": Object {
+                            "host": "localhost",
+                            "path": "",
+                            "port": "9200",
+                            "scheme": "http",
+                            "url": "",
+                          },
                           "weekly": Object {
                             "fri": false,
                             "mon": false,
@@ -444,6 +472,13 @@ exports[`MonitorIndex renders 1`] = `
                           "searchType": "graph",
                           "timeField": "",
                           "timezone": Array [],
+                          "uri": Object {
+                            "host": "localhost",
+                            "path": "",
+                            "port": "9200",
+                            "scheme": "http",
+                            "url": "",
+                          },
                           "weekly": Object {
                             "fri": false,
                             "mon": false,

--- a/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger.js
@@ -42,6 +42,7 @@ import { FORMIK_INITIAL_VALUES } from './utils/constants';
 import { SEARCH_TYPE } from '../../../../utils/constants';
 import { SubmitErrorHandler } from '../../../../utils/SubmitErrorHandler';
 import { backendErrorNotification } from '../../../../utils/helpers';
+import { buildLocalUriRequest } from '../../../CreateMonitor/containers/DefineMonitor/utils/localUriRequests';
 
 export default class CreateTrigger extends Component {
   constructor(props) {
@@ -121,12 +122,29 @@ export default class CreateTrigger extends Component {
   onRunExecute = (triggers = []) => {
     const { httpClient, monitor, notifications } = this.props;
     const formikValues = monitorToFormik(monitor);
+    const searchType = formikValues.searchType;
     const monitorToExecute = _.cloneDeep(monitor);
     _.set(monitorToExecute, 'triggers', triggers);
-    if (formikValues.searchType !== SEARCH_TYPE.AD) {
+
+    if (searchType === SEARCH_TYPE.QUERY || searchType === SEARCH_TYPE.GRAPH) {
       const searchRequest = buildSearchRequest(formikValues);
       _.set(monitorToExecute, 'inputs[0].search', searchRequest);
     }
+    if (searchType === SEARCH_TYPE.CLUSTER_API) {
+      const localUriRequest = buildLocalUriRequest(formikValues);
+      console.log('HURNEYT: CreateTrigger onRunExecute monitor = ' + JSON.stringify(monitor));
+      console.log(
+        'HURNEYT: CreateTrigger onRunExecute monitor clone = ' + JSON.stringify(monitorToExecute)
+      );
+      console.log(
+        'HURNEYT: CreateTrigger onRunExecute formikValues = ' + JSON.stringify(formikValues)
+      );
+      console.log(
+        'HURNEYT: CreateTrigger onRunExecute request = ' + JSON.stringify(localUriRequest)
+      );
+      _.set(monitorToExecute, 'inputs[0].uri', localUriRequest);
+    }
+
     httpClient
       .post('../api/alerting/monitors/_execute', { body: JSON.stringify(monitorToExecute) })
       .then((resp) => {
@@ -189,6 +207,21 @@ export default class CreateTrigger extends Component {
     error: null,
     monitor: monitor,
   });
+
+  // overrideInitialValues = () => {
+  //   const { monitor, edit, triggerToEdit } = this.props;
+  //   const { initialValues, executeResponse } = this.state;
+  //   const useTriggerToFormik = edit && triggerToEdit;
+  //
+  //   // When searchType of the monitor is 'clusterApi', override the default trigger
+  //   // condition with the first name of the name-value pairs in the response
+  //   if (!useTriggerToFormik && 'uri' in monitor.inputs[0]) {
+  //     const response = _.get(executeResponse, 'input_results.results[0]');
+  //     console.log("HURNEYT: CreateTrigger overrideInitialValues response = " + JSON.stringify(response))
+  //     _.set(initialValues, 'script.source', 'ctx.results[0].' + _.keys(response)[0] + ' != null');
+  //     this.setState({ initialValues: initialValues });
+  //   }
+  // };
 
   render() {
     const { monitor, onCloseTrigger, setFlyout, edit, httpClient, notifications } = this.props;

--- a/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger.js
@@ -132,16 +132,6 @@ export default class CreateTrigger extends Component {
     }
     if (searchType === SEARCH_TYPE.LOCAL_URI) {
       const localUriRequest = buildLocalUriRequest(formikValues);
-      console.log('HURNEYT: CreateTrigger onRunExecute monitor = ' + JSON.stringify(monitor));
-      console.log(
-        'HURNEYT: CreateTrigger onRunExecute monitor clone = ' + JSON.stringify(monitorToExecute)
-      );
-      console.log(
-        'HURNEYT: CreateTrigger onRunExecute formikValues = ' + JSON.stringify(formikValues)
-      );
-      console.log(
-        'HURNEYT: CreateTrigger onRunExecute request = ' + JSON.stringify(localUriRequest)
-      );
       _.set(monitorToExecute, 'inputs[0].uri', localUriRequest);
     }
 
@@ -149,7 +139,7 @@ export default class CreateTrigger extends Component {
       .post('../api/alerting/monitors/_execute', { body: JSON.stringify(monitorToExecute) })
       .then((resp) => {
         if (resp.ok) {
-          this.setState({ executeResponse: resp.resp });
+          this.setState({ executeResponse: resp.resp }, this.overrideInitialValues);
         } else {
           // TODO: need a notification system to show errors or banners at top
           console.error('err:', resp);
@@ -208,20 +198,19 @@ export default class CreateTrigger extends Component {
     monitor: monitor,
   });
 
-  // overrideInitialValues = () => {
-  //   const { monitor, edit, triggerToEdit } = this.props;
-  //   const { initialValues, executeResponse } = this.state;
-  //   const useTriggerToFormik = edit && triggerToEdit;
-  //
-  //   // When searchType of the monitor is 'clusterApi', override the default trigger
-  //   // condition with the first name of the name-value pairs in the response
-  //   if (!useTriggerToFormik && 'uri' in monitor.inputs[0]) {
-  //     const response = _.get(executeResponse, 'input_results.results[0]');
-  //     console.log("HURNEYT: CreateTrigger overrideInitialValues response = " + JSON.stringify(response))
-  //     _.set(initialValues, 'script.source', 'ctx.results[0].' + _.keys(response)[0] + ' != null');
-  //     this.setState({ initialValues: initialValues });
-  //   }
-  // };
+  overrideInitialValues = () => {
+    const { monitor, edit, triggerToEdit } = this.props;
+    const { initialValues, executeResponse } = this.state;
+    const useTriggerToFormik = edit && triggerToEdit;
+
+    // When searchType of the monitor is 'localUri', override the default trigger
+    // condition with the first name of the name-value pairs in the response
+    if (!useTriggerToFormik && 'uri' in monitor.inputs[0]) {
+      const response = _.get(executeResponse, 'input_results.results[0]');
+      _.set(initialValues, 'script.source', 'ctx.results[0].' + _.keys(response)[0] + ' != null');
+      this.setState({ initialValues: initialValues });
+    }
+  };
 
   render() {
     const { monitor, onCloseTrigger, setFlyout, edit, httpClient, notifications } = this.props;

--- a/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger.js
@@ -130,7 +130,7 @@ export default class CreateTrigger extends Component {
       const searchRequest = buildSearchRequest(formikValues);
       _.set(monitorToExecute, 'inputs[0].search', searchRequest);
     }
-    if (searchType === SEARCH_TYPE.CLUSTER_API) {
+    if (searchType === SEARCH_TYPE.LOCAL_URI) {
       const localUriRequest = buildLocalUriRequest(formikValues);
       console.log('HURNEYT: CreateTrigger onRunExecute monitor = ' + JSON.stringify(monitor));
       console.log(

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
@@ -75,7 +75,7 @@ export function formikToCondition(values, monitorUiMetadata = {}) {
   const searchType = _.get(monitorUiMetadata, 'search.searchType', 'query');
   const aggregationType = _.get(monitorUiMetadata, 'search.aggregationType', 'count');
 
-  if (searchType === SEARCH_TYPE.QUERY || searchType === SEARCH_TYPE.CLUSTER_API)
+  if (searchType === SEARCH_TYPE.QUERY || searchType === SEARCH_TYPE.LOCAL_URI)
     return { script: values.script };
   if (searchType === SEARCH_TYPE.AD) return getADCondition(values);
 

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
@@ -75,8 +75,10 @@ export function formikToCondition(values, monitorUiMetadata = {}) {
   const searchType = _.get(monitorUiMetadata, 'search.searchType', 'query');
   const aggregationType = _.get(monitorUiMetadata, 'search.aggregationType', 'count');
 
-  if (searchType === SEARCH_TYPE.QUERY) return { script: values.script };
+  if (searchType === SEARCH_TYPE.QUERY || searchType === SEARCH_TYPE.CLUSTER_API)
+    return { script: values.script };
   if (searchType === SEARCH_TYPE.AD) return getADCondition(values);
+
   const isCount = aggregationType === 'count';
   const resultsPath = getResultsPath(isCount);
   const operator = getOperator(thresholdEnum);

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.test.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.test.js
@@ -78,6 +78,13 @@ describe('formikToCondition', () => {
     });
   });
 
+  test('can return condition when searchType is localUri', () => {
+    const formikValues = _.cloneDeep(FORMIK_INITIAL_VALUES);
+    expect(formikToCondition(formikValues, { search: { searchType: 'localUri' } })).toEqual({
+      script: formikValues.script,
+    });
+  });
+
   test('can return condition when searchType is ad', () => {
     const formikValues = _.cloneDeep(FORMIK_INITIAL_VALUES);
     expect(formikToCondition(formikValues, { search: { searchType: 'ad' } })).toEqual({

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
@@ -27,8 +27,24 @@ function getTime(time) {
   return DEFAULT_EMPTY_DATA;
 }
 
+function getMonitorType(searchType) {
+  switch (searchType) {
+    case SEARCH_TYPE.GRAPH:
+      return 'Visual Graph';
+    case SEARCH_TYPE.AD:
+      return 'Anomaly Detector';
+    case SEARCH_TYPE.CLUSTER_API:
+      return 'Cluster API';
+    default:
+      return 'Extraction Query';
+  }
+}
+
 export default function getOverviewStats(monitor, monitorId, monitorVersion, activeCount) {
-  const searchType = _.get(monitor, 'ui_metadata.search.searchType', 'query');
+  let searchType = _.get(monitor, 'ui_metadata.search.searchType', 'query');
+  if (_.has(monitor, 'inputs[0].uri')) {
+    searchType = SEARCH_TYPE.CLUSTER_API;
+  }
   return [
     {
       header: 'State',
@@ -36,7 +52,7 @@ export default function getOverviewStats(monitor, monitorId, monitorVersion, act
     },
     {
       header: 'Monitor definition type',
-      value: searchType === SEARCH_TYPE.QUERY ? 'Extraction Query' : 'Visual graph',
+      value: getMonitorType(searchType),
     },
     {
       header: 'Total active alerts',

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
@@ -33,8 +33,8 @@ function getMonitorType(searchType) {
       return 'Visual Graph';
     case SEARCH_TYPE.AD:
       return 'Anomaly Detector';
-    case SEARCH_TYPE.CLUSTER_API:
-      return 'Cluster API';
+    case SEARCH_TYPE.LOCAL_URI:
+      return 'Local URI';
     default:
       return 'Extraction Query';
   }
@@ -43,7 +43,7 @@ function getMonitorType(searchType) {
 export default function getOverviewStats(monitor, monitorId, monitorVersion, activeCount) {
   let searchType = _.get(monitor, 'ui_metadata.search.searchType', 'query');
   if (_.has(monitor, 'inputs[0].uri')) {
-    searchType = SEARCH_TYPE.CLUSTER_API;
+    searchType = SEARCH_TYPE.LOCAL_URI;
   }
   return [
     {

--- a/public/utils/constants.js
+++ b/public/utils/constants.js
@@ -32,7 +32,7 @@ export const SEARCH_TYPE = {
   GRAPH: 'graph',
   QUERY: 'query',
   AD: 'ad',
-  CLUSTER_API: 'clusterApi',
+  LOCAL_URI: 'localUri',
 };
 
 export const DESTINATION_ACTIONS = {

--- a/public/utils/constants.js
+++ b/public/utils/constants.js
@@ -32,6 +32,7 @@ export const SEARCH_TYPE = {
   GRAPH: 'graph',
   QUERY: 'query',
   AD: 'ad',
+  CLUSTER_API: 'clusterApi',
 };
 
 export const DESTINATION_ACTIONS = {


### PR DESCRIPTION
*Issue #, if available:* [166](https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/pull/166)

*Description of changes:*
This PR is inherited from [#166](https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/pull/166). 
Implementations are adapted from #166 for use with `LocalUriInput`.

**Internal Changes**
1. Refactored `HttpInput` to `LocalUriInput` to reflect that this feature only supports local clusters at this time. Only a `path` field has been exposed as `host` and `port` only support `localhost` and `9200` for now.
2. Modified several components to make the `create monitor`, `edit monitor`, and `create trigger` pages display properly for `LocalUriInput` type monitors.
3. Modified `formikToMonitor.js` to handle `LocalUriInput` type monitors.
4. Added `LocalUriInput.test.js` snapshot test.
5. Added snapshot tests for `formikToInputs()` and `formikToLocalUri()` in `formikToMonitor.test.js`.
6. Added `can build LocalUriInput monitor` test to `monitorToFormik.test.js`.

**External Changes**
1. Modified `getOverviewStats` to display `Local URI` definition type.
2. The `Response` block on the create monitor page will display the response contents for the API called using the provided `path`.
3. Modified `CreateTrigger.js` such that the `Trigger Condition` block on the create trigger page will display the first field name in the API response for LocalUriInput monitors (e.g., `ctx.results[0].XXX != null`).

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.