### PR TITLE
Fixed an issue preventing emails from being added to an email group using the Kibana interface.

### DIFF
--- a/public/pages/Destinations/components/createDestinations/Email/EmailGroup.js
+++ b/public/pages/Destinations/components/createDestinations/Email/EmailGroup.js
@@ -95,6 +95,7 @@ const EmailGroup = ({ emailGroup, emailOptions, arrayHelpers, context, index, on
             form.setFieldTouched(`emailGroups.${index}.emails`, true);
           },
           onCreateOption: (value, field, form) => {
+            onEmailGroupChange(index, emailGroup, arrayHelpers);
             onCreateOption(`emailGroups.${index}.emails`, value, field.value, form.setFieldValue);
           },
           isClearable: true,


### PR DESCRIPTION
**Issue #, if available:**
[Issue #352](https://github.com/opendistro-for-elasticsearch/alerting/issues/352)

**Description of changes:**
The `emailGroup` `state` was not being changed to `updated` in `EmailGroup.js` which was preventing `ManageEmailGroups.js` from updating the group in the `processEmailGroups` method.

Added a `onEmailGroupChange` call to the `onCreateOption` block in `EmailGroup.js`, allowing the `emailGroup`'s `state` to be changed when a new email is added to the input field. This allows the new emails to successfully be added to the group on the backend, as well as display as expected on the frontend.

**Testing:**
`GET _opendistro/_alerting/destinations/email_groups/<email_group_id>` successfully returns all email addresses provided in the input field when updating the email group.


By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.