### PR TITLE
Implemented support for rendering multiple trigger conditions for visual graph aggregation monitors.

### DIFF
--- a/public/pages/CreateMonitor/containers/Query/Query.js
+++ b/public/pages/CreateMonitor/containers/Query/Query.js
@@ -165,7 +165,9 @@ class Query extends Component {
           + Add another metric
         </EuiButtonEmpty>
         <EuiSpacer size="s" />
+
         <EuiText size="xs">
+          {' '}
           <h4>For the last</h4>
         </EuiText>
         {/*TODO: Fix the alignment of the following definition to left side*/}
@@ -183,6 +185,37 @@ class Query extends Component {
             />
           </EuiFlexItem>
         </EuiFlexGroup>
+        <EuiSpacer size="s" />
+
+        <EuiText size="xs">
+          {' '}
+          <h4>Where</h4>{' '}
+        </EuiText>
+        <EuiButtonEmpty
+          size="xs"
+          data-test-subj="addFilterButton"
+          // onClick={}
+        >
+          + Add filter
+        </EuiButtonEmpty>
+
+        <EuiSpacer size="s" />
+
+        <EuiText size="xs">
+          {' '}
+          <h4>Group by</h4>{' '}
+        </EuiText>
+
+        <EuiButtonEmpty
+          size="xs"
+          data-test-subj="addGroupByButton"
+          // onClick={}
+        >
+          + Add another group by
+        </EuiButtonEmpty>
+
+        <EuiSpacer size="s" />
+
         {errors.where ? (
           renderEmptyMessage('Invalid input in WHERE filter. Remove WHERE filter or adjust filter ')
         ) : (

--- a/public/pages/CreateTrigger/components/AddTriggerButton/AddTriggerButton.js
+++ b/public/pages/CreateTrigger/components/AddTriggerButton/AddTriggerButton.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import _ from 'lodash';
+import { EuiButton } from '@elastic/eui';
+import { FORMIK_INITIAL_TRIGGER_CONDITION_VALUES } from '../../containers/CreateTrigger/utils/constants';
+
+const AddTriggerButton = ({ arrayHelpers }) => (
+  <EuiButton
+    fill
+    onClick={() => arrayHelpers.push(_.cloneDeep(FORMIK_INITIAL_TRIGGER_CONDITION_VALUES))}
+  >
+    + Add condition
+  </EuiButton>
+);
+
+export default AddTriggerButton;

--- a/public/pages/CreateTrigger/components/AddTriggerButton/index.js
+++ b/public/pages/CreateTrigger/components/AddTriggerButton/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import AddTriggerButton from './AddTriggerButton';
+
+export default AddTriggerButton;

--- a/public/pages/CreateTrigger/components/AggregationTriggerExpression/AggregationTriggerExpression.js
+++ b/public/pages/CreateTrigger/components/AggregationTriggerExpression/AggregationTriggerExpression.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React, { Component } from 'react';
+import _ from 'lodash';
+import { Field } from 'formik';
+import {
+  EuiExpression,
+  EuiFieldNumber,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiPopover,
+  EuiSelect,
+} from '@elastic/eui';
+
+const DEFAULT_CLOSED_STATES = { THRESHOLD: false };
+export const Expressions = { THRESHOLD: 'THRESHOLD' };
+const POPOVER_STYLE = { zIndex: '200' };
+
+const THRESHOLD_ENUM_OPTIONS = [
+  { value: 'ABOVE', text: 'IS ABOVE' },
+  { value: 'BELOW', text: 'IS BELOW' },
+  { value: 'EXACTLY', text: 'IS EXACTLY' },
+];
+
+const AND_OR_CONDITION_OPTIONS = [
+  { value: 'AND', text: 'AND' },
+  { value: 'OR', text: 'OR' },
+];
+
+class AggregationTriggerExpression extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      openedStates: { ...DEFAULT_CLOSED_STATES },
+    };
+
+    this.openExpression = this.openExpression.bind(this);
+    this.closeExpression = this.closeExpression.bind(this);
+  }
+
+  openExpression(expression) {
+    this.setState({ openedStates: { ...DEFAULT_CLOSED_STATES, [expression]: true } });
+  }
+
+  closeExpression(expression) {
+    const { openedStates } = this.state;
+    this.setState({ openedStates: { ...openedStates, [expression]: false } });
+  }
+
+  renderPopover() {
+    const {
+      queryMetrics,
+      index,
+      andOrConditionFieldName,
+      queryMetricFieldName,
+      enumFieldName,
+      valueFieldName,
+    } = this.props;
+    return (
+      <div style={POPOVER_STYLE}>
+        <EuiFlexGroup
+          style={{
+            maxWidth: 600,
+            padding: '20px',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {index > 0 ? (
+            <EuiFlexItem grow={false} style={{ width: 100 }}>
+              <Field name={andOrConditionFieldName}>
+                {({ field: { onBlur, ...rest }, form: { touched, errors } }) => (
+                  <EuiFormRow
+                    style={{ paddingLeft: '10px' }}
+                    isInvalid={touched.andOrCondition && !!errors.andOrCondition}
+                    error={errors.andOrCondition}
+                  >
+                    <EuiSelect options={AND_OR_CONDITION_OPTIONS} {...rest} />
+                  </EuiFormRow>
+                )}
+              </Field>
+            </EuiFlexItem>
+          ) : null}
+
+          <EuiFlexItem grow={false} style={{ width: 150 }}>
+            <Field name={queryMetricFieldName}>
+              {({ field: { onBlur, ...rest }, form: { touched, errors } }) => (
+                <EuiFormRow
+                  style={{ paddingLeft: '10px' }}
+                  isInvalid={touched.queryMetric && !!errors.queryMetric}
+                  error={errors.queryMetric}
+                >
+                  <EuiSelect options={queryMetrics} {...rest} />
+                </EuiFormRow>
+              )}
+            </Field>
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={false} style={{ width: 150 }}>
+            <Field name={enumFieldName}>
+              {({ field: { onBlur, ...rest }, form: { touched, errors } }) => (
+                <EuiFormRow
+                  style={{ paddingLeft: '10px' }}
+                  isInvalid={touched.thresholdEnum && !!errors.thresholdEnum}
+                  error={errors.thresholdEnum}
+                >
+                  <EuiSelect options={THRESHOLD_ENUM_OPTIONS} {...rest} />
+                </EuiFormRow>
+              )}
+            </Field>
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={false} style={{ width: 100 }}>
+            <Field name={valueFieldName}>
+              {({ field, form: { touched, errors } }) => (
+                <EuiFormRow
+                  style={{ paddingLeft: '10px' }}
+                  isInvalid={touched.thresholdValue && !!errors.thresholdValue}
+                  error={errors.thresholdValue}
+                >
+                  <EuiFieldNumber {...field} />
+                </EuiFormRow>
+              )}
+            </Field>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </div>
+    );
+  }
+
+  render() {
+    const { openedStates } = this.state;
+    const {
+      index,
+      andOrCondition,
+      queryMetric,
+      queryMetrics,
+      thresholdEnum,
+      thresholdValue,
+      label,
+    } = this.props;
+
+    return (
+      <EuiFlexGroup alignItems={'center'}>
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            id="aggregation-trigger-popover"
+            button={
+              <EuiFormRow label={label}>
+                <div>
+                  {index > 0 ? (
+                    <EuiExpression
+                      description={`${
+                        _.isEmpty(andOrCondition)
+                          ? AND_OR_CONDITION_OPTIONS[0].text
+                          : andOrCondition
+                      }`}
+                      value={''}
+                      isActive={openedStates.THRESHOLD}
+                      onClick={() => this.openExpression(Expressions.THRESHOLD)}
+                    />
+                  ) : null}
+                  <EuiExpression
+                    description={'WHEN '}
+                    value={`${
+                      _.isEmpty(queryMetric) ? _.get(queryMetrics[0], 'text', '-') : queryMetric
+                    }`}
+                    isActive={openedStates.THRESHOLD}
+                    onClick={() => this.openExpression(Expressions.THRESHOLD)}
+                  />
+                  <EuiExpression
+                    description={`IS ${thresholdEnum}`}
+                    value={`${thresholdValue.toLocaleString()}`}
+                    isActive={openedStates.THRESHOLD}
+                    onClick={() => this.openExpression(Expressions.THRESHOLD)}
+                  />
+                </div>
+              </EuiFormRow>
+            }
+            isOpen={openedStates.THRESHOLD}
+            closePopover={() => this.closeExpression(Expressions.THRESHOLD)}
+            panelPaddingSize="none"
+            ownFocus
+            withTitle
+            anchorPosition="downLeft"
+          >
+            {this.renderPopover()}
+          </EuiPopover>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+}
+
+export default AggregationTriggerExpression;

--- a/public/pages/CreateTrigger/components/AggregationTriggerExpression/index.js
+++ b/public/pages/CreateTrigger/components/AggregationTriggerExpression/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import AggregationTriggerExpression from './AggregationTriggerExpression';
+
+export default AggregationTriggerExpression;

--- a/public/pages/CreateTrigger/components/AggregationTriggerGraph.js
+++ b/public/pages/CreateTrigger/components/AggregationTriggerGraph.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { EuiSpacer } from '@elastic/eui';
+import AggregationTriggerExpression from './AggregationTriggerExpression';
+
+const AggregationTriggerGraph = ({
+  index,
+  andOrCondition,
+  monitorValues,
+  response,
+  queryMetric,
+  queryMetrics,
+  thresholdEnum,
+  thresholdValue,
+}) => (
+  <div style={{ padding: '0px 10px' }}>
+    <AggregationTriggerExpression
+      index={index}
+      andOrCondition={andOrCondition}
+      queryMetric={queryMetric}
+      queryMetrics={queryMetrics}
+      thresholdEnum={thresholdEnum}
+      thresholdValue={thresholdValue}
+      andOrConditionFieldName={
+        index === undefined ? 'andOrCondition' : `triggerConditions[${index}].andOrCondition`
+      }
+      queryMetricFieldName={
+        index === undefined ? 'queryMetric' : `triggerConditions[${index}].queryMetric`
+      }
+      enumFieldName={
+        index === undefined ? 'thresholdEnum' : `triggerConditions[${index}].thresholdEnum`
+      }
+      valueFieldName={
+        index === undefined ? 'thresholdValue' : `triggerConditions[${index}].thresholdValue`
+      }
+      label="Trigger conditions"
+    />
+    <EuiSpacer size={'s'} />
+    {/*TODO: Implement VisualGraph illustrating the trigger expression similar to the implementation in TriggerGraph.js*/}
+  </div>
+);
+
+export default AggregationTriggerGraph;

--- a/public/pages/CreateTrigger/components/AggregationTriggerQuery/AggregationTriggerQuery.js
+++ b/public/pages/CreateTrigger/components/AggregationTriggerQuery/AggregationTriggerQuery.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { Field } from 'formik';
+import _ from 'lodash';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCodeEditor,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiSpacer,
+} from '@elastic/eui';
+import 'brace/mode/json';
+import 'brace/mode/plain_text';
+import 'brace/snippets/javascript';
+import 'brace/ext/language_tools';
+import { formikToTrigger } from '../../containers/CreateTrigger/utils/formikToTrigger';
+
+export const getExecuteMessage = (response) => {
+  if (!response) return 'No response';
+  const triggerResults = _.get(response, 'trigger_results');
+  if (!triggerResults) return 'No trigger results';
+  const triggerId = Object.keys(triggerResults)[0];
+  if (!triggerId) return 'No trigger results';
+  const executeResults = _.get(triggerResults, `${triggerId}`);
+  if (!executeResults) return 'No execute results';
+  const { error, triggered } = executeResults;
+  return error || `${triggered}`;
+};
+
+const AggregationTriggerQuery = ({
+  index,
+  context,
+  error,
+  executeResponse,
+  onRun,
+  response,
+  setFlyout,
+  triggerValues,
+  isDarkMode,
+}) => {
+  const trigger = { ...formikToTrigger(triggerValues), actions: [] };
+  const formattedResponse = JSON.stringify(response, null, 4);
+  const fieldName = index === null ? 'script.source' : `triggerConditions[${index}].script.source`;
+  return (
+    <div style={{ padding: '0px 10px', marginTop: '0px' }}>
+      <EuiFlexGroup direction="column">
+        <EuiFlexItem>
+          <EuiFormRow label="Extraction query response" fullWidth>
+            <EuiCodeEditor
+              mode="json"
+              theme={isDarkMode ? 'sense-dark' : 'github'}
+              width="100%"
+              value={error || formattedResponse}
+              readOnly
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <Field name={fieldName}>
+            {({ field: { value }, form: { errors, touched, setFieldValue, setFieldTouched } }) => (
+              <EuiFormRow
+                label={
+                  <div>
+                    <span>Trigger condition</span>
+                    <EuiButtonEmpty
+                      size="s"
+                      onClick={() => {
+                        setFlyout({ type: 'triggerCondition', payload: context });
+                      }}
+                    >
+                      Info
+                    </EuiButtonEmpty>
+                  </div>
+                }
+                fullWidth
+                isInvalid={_.get(touched, fieldName, false) && !!_.get(errors, fieldName)}
+                error={_.get(errors, fieldName)}
+              >
+                <EuiCodeEditor
+                  mode="plain_text"
+                  theme={isDarkMode ? 'sense-dark' : 'github'}
+                  height="200px"
+                  width="100%"
+                  onChange={(source) => {
+                    setFieldValue(fieldName, source);
+                  }}
+                  onBlur={() => setFieldTouched(fieldName, true)}
+                  value={value}
+                />
+              </EuiFormRow>
+            )}
+          </Field>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiFormRow label="Trigger condition response:" fullWidth>
+            <EuiCodeEditor
+              mode="plain_text"
+              theme={isDarkMode ? 'sense-dark' : 'github'}
+              width="100%"
+              height="200px"
+              value={getExecuteMessage(executeResponse)}
+              readOnly
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="s" />
+
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButton onClick={() => onRun([trigger])}>Run</EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  );
+};
+
+export default AggregationTriggerQuery;

--- a/public/pages/CreateTrigger/components/AggregationTriggerQuery/index.js
+++ b/public/pages/CreateTrigger/components/AggregationTriggerQuery/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import AggregationTriggerQuery from './AggregationTriggerQuery';
+
+export default AggregationTriggerQuery;

--- a/public/pages/CreateTrigger/components/TriggerEmptyPrompt/TriggerEmptyPrompt.js
+++ b/public/pages/CreateTrigger/components/TriggerEmptyPrompt/TriggerEmptyPrompt.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { EuiEmptyPrompt, EuiText } from '@elastic/eui';
+import AddTriggerButton from '../AddTriggerButton';
+
+const addTriggerButton = (arrayHelpers) => <AddTriggerButton arrayHelpers={arrayHelpers} />;
+
+const TriggerEmptyPrompt = ({ arrayHelpers }) => (
+  <EuiEmptyPrompt
+    style={{ maxWidth: '45em' }}
+    body={
+      <EuiText>
+        <p>Create a trigger condition to start alerting.</p>
+      </EuiText>
+    }
+    actions={addTriggerButton(arrayHelpers)}
+  />
+);
+
+export default TriggerEmptyPrompt;

--- a/public/pages/CreateTrigger/components/TriggerEmptyPrompt/index.js
+++ b/public/pages/CreateTrigger/components/TriggerEmptyPrompt/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import TriggerEmptyPrompt from './TriggerEmptyPrompt';
+
+export default TriggerEmptyPrompt;

--- a/public/pages/CreateTrigger/components/TriggerGraph.js
+++ b/public/pages/CreateTrigger/components/TriggerGraph.js
@@ -18,13 +18,17 @@ import { EuiSpacer } from '@elastic/eui';
 import VisualGraph from '../../CreateMonitor/components/VisualGraph';
 import TriggerExpressions from './TriggerExpressions';
 
-const TriggerGraph = ({ monitorValues, response, thresholdValue, thresholdEnum }) => (
+const TriggerGraph = ({ index, monitorValues, response, thresholdValue, thresholdEnum }) => (
   <div style={{ padding: '0px 10px' }}>
     <TriggerExpressions
       thresholdValue={thresholdValue}
       thresholdEnum={thresholdEnum}
-      keyFieldName="thresholdEnum"
-      valueFieldName="thresholdValue"
+      keyFieldName={
+        index === undefined ? 'thresholdEnum' : `triggerConditions[${index}].thresholdEnum`
+      }
+      valueFieldName={
+        index === undefined ? 'thresholdValue' : `triggerConditions[${index}].thresholdValue`
+      }
       label="Trigger condition"
     />
     <EuiSpacer size="s" />

--- a/public/pages/CreateTrigger/components/TriggerQuery/TriggerQuery.js
+++ b/public/pages/CreateTrigger/components/TriggerQuery/TriggerQuery.js
@@ -52,9 +52,11 @@ const TriggerQuery = ({
   triggerValues,
   setFlyout,
   isDarkMode,
+  index,
 }) => {
   const trigger = { ...formikToTrigger(triggerValues), actions: [] };
   const formattedResponse = JSON.stringify(response, null, 4);
+  const fieldName = index === null ? 'script.source' : `triggerConditions[${index}].script.source`;
   return (
     <div style={{ padding: '0px 10px', marginTop: '0px' }}>
       <EuiFlexGroup direction="column">
@@ -70,7 +72,7 @@ const TriggerQuery = ({
           </EuiFormRow>
         </EuiFlexItem>
         <EuiFlexItem>
-          <Field name="script.source">
+          <Field name={fieldName}>
             {({ field: { value }, form: { errors, touched, setFieldValue, setFieldTouched } }) => (
               <EuiFormRow
                 label={
@@ -87,10 +89,8 @@ const TriggerQuery = ({
                   </div>
                 }
                 fullWidth
-                isInvalid={
-                  _.get(touched, 'script.source', false) && !!_.get(errors, 'script.source')
-                }
-                error={_.get(errors, 'script.source')}
+                isInvalid={_.get(touched, fieldName, false) && !!_.get(errors, fieldName)}
+                error={_.get(errors, fieldName)}
               >
                 <EuiCodeEditor
                   mode="plain_text"
@@ -98,9 +98,9 @@ const TriggerQuery = ({
                   height="200px"
                   width="100%"
                   onChange={(source) => {
-                    setFieldValue('script.source', source);
+                    setFieldValue(fieldName, source);
                   }}
-                  onBlur={() => setFieldTouched('script.source', true)}
+                  onBlur={() => setFieldTouched(fieldName, true)}
                   value={value}
                 />
               </EuiFormRow>

--- a/public/pages/CreateTrigger/components/TriggerQuery/TriggerQuery.test.js
+++ b/public/pages/CreateTrigger/components/TriggerQuery/TriggerQuery.test.js
@@ -18,7 +18,7 @@ import { shallow } from 'enzyme';
 import { EuiButton } from '@elastic/eui';
 
 import TriggerQuery, { getExecuteMessage } from './TriggerQuery';
-import { FORMIK_INITIAL_VALUES } from '../../containers/CreateTrigger/utils/constants';
+import { FORMIK_INITIAL_TRIGGER_VALUES } from '../../containers/CreateTrigger/utils/constants';
 import { formikToTrigger } from '../../containers/CreateTrigger/utils/formikToTrigger';
 
 const props = {
@@ -26,7 +26,7 @@ const props = {
   executeResponse: null,
   onRun: jest.fn(),
   response: null,
-  triggerValues: FORMIK_INITIAL_VALUES,
+  triggerValues: FORMIK_INITIAL_TRIGGER_VALUES,
   setFlyout: jest.fn(),
 };
 

--- a/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger.js
@@ -42,6 +42,17 @@ import { FORMIK_INITIAL_TRIGGER_VALUES } from './utils/constants';
 import { SEARCH_TYPE } from '../../../../utils/constants';
 import { SubmitErrorHandler } from '../../../../utils/SubmitErrorHandler';
 import { backendErrorNotification } from '../../../../utils/helpers';
+import DefineAggregationTrigger from '../DefineAggregationTrigger';
+import { getPathsPerDataType } from '../../../CreateMonitor/containers/DefineMonitor/utils/mappings';
+
+export const DEFAULT_CLOSED_STATES = {
+  WHEN: false,
+  OF_FIELD: false,
+  THRESHOLD: false,
+  OVER: false,
+  FOR_THE_LAST: false,
+  WHERE: false,
+};
 
 export default class CreateTrigger extends Component {
   constructor(props) {
@@ -56,11 +67,15 @@ export default class CreateTrigger extends Component {
       triggerResponse: null,
       executeResponse: null,
       initialValues,
+      dataTypes: {},
+      openedStates: DEFAULT_CLOSED_STATES,
+      madeChanges: false,
     };
   }
 
   componentDidMount() {
     this.onRunExecute();
+    this.onQueryMappings();
   }
 
   componentWillUnmount() {
@@ -190,9 +205,70 @@ export default class CreateTrigger extends Component {
     monitor: monitor,
   });
 
+  openExpression = (expression) => {
+    this.setState({
+      openedStates: {
+        ...DEFAULT_CLOSED_STATES,
+        [expression]: true,
+      },
+    });
+  };
+
+  closeExpression = (expression) => {
+    const { madeChanges, openedStates } = this.state;
+    if (madeChanges && openedStates[expression]) {
+      // if made changes and close expression that was currently open => run query
+      this.props.onRunQuery();
+      this.setState({ madeChanges: false });
+    }
+    this.setState({ openedStates: { ...openedStates, [expression]: false } });
+  };
+
+  onMadeChanges = () => {
+    this.setState({ madeChanges: true });
+  };
+
+  getExpressionProps = () => ({
+    openedStates: this.state.openedStates,
+    closeExpression: this.closeExpression,
+    openExpression: this.openExpression,
+    onMadeChanges: this.onMadeChanges,
+  });
+
+  async queryMappings(index) {
+    if (!index.length) {
+      return {};
+    }
+
+    try {
+      const response = await this.props.httpClient.post('../api/alerting/_mappings', {
+        body: JSON.stringify({ index }),
+      });
+      if (response.ok) {
+        return response.resp;
+      }
+      return {};
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  async onQueryMappings() {
+    const index = this.props.values.index.map(({ label }) => label);
+    try {
+      const mappings = await this.queryMappings(index);
+      const dataTypes = getPathsPerDataType(mappings);
+      this.setState({ dataTypes });
+    } catch (err) {
+      console.error('There was an error getting mappings for query', err);
+    }
+  }
+
   render() {
     const { monitor, onCloseTrigger, setFlyout, edit, httpClient, notifications } = this.props;
-    const { initialValues, executeResponse } = this.state;
+    const { dataTypes, initialValues, executeResponse } = this.state;
+    const isTraditionalMonitor = _.get(monitor, 'monitor_type') === 'traditional_monitor';
+
     return (
       <div style={{ padding: '25px 50px' }}>
         {this.renderSuccessCallOut()}
@@ -203,21 +279,40 @@ export default class CreateTrigger extends Component {
                 <h1>{edit ? 'Edit' : 'Create'} trigger</h1>
               </EuiTitle>
               <EuiSpacer />
-              <FieldArray name={'triggerConditions'} validateOnChange={true}>
-                {(arrayHelpers) => (
-                  <DefineTrigger
-                    arrayHelpers={arrayHelpers}
-                    context={this.getTriggerContext(executeResponse, monitor, values)}
-                    executeResponse={executeResponse}
-                    monitorValues={monitorToFormik(monitor)}
-                    onRun={this.onRunExecute}
-                    setFlyout={setFlyout}
-                    triggers={monitor.triggers}
-                    triggerValues={values}
-                    isDarkMode={this.props.isDarkMode}
-                  />
-                )}
-              </FieldArray>
+              {isTraditionalMonitor ? (
+                <DefineTrigger
+                  context={this.getTriggerContext(executeResponse, monitor, values)}
+                  executeResponse={executeResponse}
+                  monitorValues={monitorToFormik(monitor)}
+                  onRun={this.onRunExecute}
+                  setFlyout={setFlyout}
+                  triggers={monitor.triggers}
+                  triggerValues={values}
+                  isDarkMode={this.props.isDarkMode}
+                />
+              ) : (
+                <FieldArray name={'triggerConditions'} validateOnChange={true}>
+                  {(arrayHelpers) => (
+                    <DefineAggregationTrigger
+                      arrayHelpers={arrayHelpers}
+                      context={this.getTriggerContext(executeResponse, monitor, values)}
+                      executeResponse={executeResponse}
+                      monitor={monitor}
+                      monitorValues={monitorToFormik(monitor)}
+                      onRun={this.onRunExecute}
+                      setFlyout={setFlyout}
+                      triggers={monitor.triggers}
+                      triggerValues={values}
+                      isDarkMode={this.props.isDarkMode}
+                      openedStates={this.state.openedStates}
+                      closeExpression={this.closeExpression}
+                      openExpression={this.openExpression}
+                      onMadeChanges={this.onMadeChanges}
+                      dataTypes={dataTypes}
+                    />
+                  )}
+                </FieldArray>
+              )}
               <EuiSpacer />
               <FieldArray name="actions" validateOnChange={true}>
                 {(arrayHelpers) => (

--- a/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger.js
@@ -38,7 +38,7 @@ import monitorToFormik from '../../../CreateMonitor/containers/CreateMonitor/uti
 import { buildSearchRequest } from '../../../CreateMonitor/containers/DefineMonitor/utils/searchRequests';
 import { formikToTrigger, formikToTriggerUiMetadata } from './utils/formikToTrigger';
 import { triggerToFormik } from './utils/triggerToFormik';
-import { FORMIK_INITIAL_VALUES } from './utils/constants';
+import { FORMIK_INITIAL_TRIGGER_VALUES } from './utils/constants';
 import { SEARCH_TYPE } from '../../../../utils/constants';
 import { SubmitErrorHandler } from '../../../../utils/SubmitErrorHandler';
 import { backendErrorNotification } from '../../../../utils/helpers';
@@ -50,7 +50,7 @@ export default class CreateTrigger extends Component {
     const useTriggerToFormik = this.props.edit && this.props.triggerToEdit;
     const initialValues = useTriggerToFormik
       ? triggerToFormik(this.props.triggerToEdit, this.props.monitor)
-      : _.cloneDeep(FORMIK_INITIAL_VALUES);
+      : _.cloneDeep(FORMIK_INITIAL_TRIGGER_VALUES);
 
     this.state = {
       triggerResponse: null,
@@ -203,16 +203,21 @@ export default class CreateTrigger extends Component {
                 <h1>{edit ? 'Edit' : 'Create'} trigger</h1>
               </EuiTitle>
               <EuiSpacer />
-              <DefineTrigger
-                context={this.getTriggerContext(executeResponse, monitor, values)}
-                executeResponse={executeResponse}
-                monitorValues={monitorToFormik(monitor)}
-                onRun={this.onRunExecute}
-                setFlyout={setFlyout}
-                triggers={monitor.triggers}
-                triggerValues={values}
-                isDarkMode={this.props.isDarkMode}
-              />
+              <FieldArray name={'triggerConditions'} validateOnChange={true}>
+                {(arrayHelpers) => (
+                  <DefineTrigger
+                    arrayHelpers={arrayHelpers}
+                    context={this.getTriggerContext(executeResponse, monitor, values)}
+                    executeResponse={executeResponse}
+                    monitorValues={monitorToFormik(monitor)}
+                    onRun={this.onRunExecute}
+                    setFlyout={setFlyout}
+                    triggers={monitor.triggers}
+                    triggerValues={values}
+                    isDarkMode={this.props.isDarkMode}
+                  />
+                )}
+              </FieldArray>
               <EuiSpacer />
               <FieldArray name="actions" validateOnChange={true}>
                 {(arrayHelpers) => (

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
@@ -13,6 +13,8 @@
  *   permissions and limitations under the License.
  */
 
+import { OPERATORS_MAP } from '../../../../CreateMonitor/components/MonitorExpressions/expressions/utils/constants';
+
 export const TRIGGER_TYPE = {
   AD: 'anomaly_detector_trigger',
   ALERT_TRIGGER: 'alerting_trigger',
@@ -32,6 +34,8 @@ export const FORMIK_INITIAL_TRIGGER_CONDITION_VALUES = {
     lang: 'painless',
     source: 'ctx.results[0].hits.total.value > 0',
   },
+  queryMetric: '',
+  andOrCondition: '',
 };
 
 export const FORMIK_INITIAL_TRIGGER_VALUES = {
@@ -52,6 +56,13 @@ export const FORMIK_INITIAL_TRIGGER_VALUES = {
     anomalyGradeThresholdEnum: 'ABOVE',
     anomalyConfidenceThresholdValue: 0.7,
     anomalyConfidenceThresholdEnum: 'ABOVE',
+  },
+  where: {
+    fieldName: [],
+    operator: OPERATORS_MAP.IS,
+    fieldValue: '',
+    fieldRangeStart: 0,
+    fieldRangeEnd: 0,
   },
   actions: undefined,
 };

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
@@ -18,7 +18,19 @@ export const TRIGGER_TYPE = {
   ALERT_TRIGGER: 'alerting_trigger',
 };
 
-export const FORMIK_INITIAL_VALUES = {
+export const FORMIK_INITIAL_TRIGGER_CONDITION_VALUES = {
+  thresholdValue: 10000,
+  thresholdEnum: 'ABOVE',
+  anomalyDetector: {
+    triggerType: TRIGGER_TYPE.AD,
+    anomalyGradeThresholdValue: 0.7,
+    anomalyGradeThresholdEnum: 'ABOVE',
+    anomalyConfidenceThresholdValue: 0.7,
+    anomalyConfidenceThresholdEnum: 'ABOVE',
+  },
+};
+
+export const FORMIK_INITIAL_TRIGGER_VALUES = {
   name: '',
   severity: '1',
   minTimeBetweenExecutions: null,
@@ -27,6 +39,7 @@ export const FORMIK_INITIAL_VALUES = {
     lang: 'painless',
     source: `ctx.results[0].hits.total.value > 0`,
   },
+  triggerConditions: undefined,
   thresholdValue: 10000,
   thresholdEnum: 'ABOVE',
   anomalyDetector: {

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
@@ -28,6 +28,10 @@ export const FORMIK_INITIAL_TRIGGER_CONDITION_VALUES = {
     anomalyConfidenceThresholdValue: 0.7,
     anomalyConfidenceThresholdEnum: 'ABOVE',
   },
+  script: {
+    lang: 'painless',
+    source: 'ctx.results[0].hits.total.value > 0',
+  },
 };
 
 export const FORMIK_INITIAL_TRIGGER_VALUES = {

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
@@ -32,6 +32,7 @@ export function formikToTrigger(values, monitorUiMetadata = {}) {
     name: values.name,
     severity: values.severity,
     condition,
+    triggerConditions: values.triggerConditions,
     actions: actions,
     min_time_between_executions: values.minTimeBetweenExecutions,
     rolling_window_size: values.rollingWindowSize,

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.test.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.test.js
@@ -16,12 +16,12 @@
 import _ from 'lodash';
 import { formikToTrigger, formikToTriggerUiMetadata, formikToCondition } from './formikToTrigger';
 
-import { FORMIK_INITIAL_VALUES } from './constants';
+import { FORMIK_INITIAL_TRIGGER_VALUES } from './constants';
 import { SEARCH_TYPE } from '../../../../../utils/constants';
 
 describe('formikToTrigger', () => {
   test('can create trigger', () => {
-    const formikValues = _.cloneDeep(FORMIK_INITIAL_VALUES);
+    const formikValues = _.cloneDeep(FORMIK_INITIAL_TRIGGER_VALUES);
     expect(formikToTrigger(formikValues)).toEqual({
       name: formikValues.name,
       severity: formikValues.severity,
@@ -35,7 +35,7 @@ describe('formikToTrigger', () => {
 
 describe('formikToTriggerUiMetadata', () => {
   test('can create trigger metadata for AD monitors', () => {
-    const formikValues = _.cloneDeep(FORMIK_INITIAL_VALUES);
+    const formikValues = _.cloneDeep(FORMIK_INITIAL_TRIGGER_VALUES);
     expect(
       formikToTriggerUiMetadata(formikValues, { search: { searchType: SEARCH_TYPE.AD } })
     ).toEqual({
@@ -58,7 +58,7 @@ describe('formikToTriggerUiMetadata', () => {
   });
 
   test('can create metadata', () => {
-    const formikValues = _.cloneDeep(FORMIK_INITIAL_VALUES);
+    const formikValues = _.cloneDeep(FORMIK_INITIAL_TRIGGER_VALUES);
     expect(
       formikToTriggerUiMetadata(formikValues, { search: { searchType: SEARCH_TYPE.QUERY } })
     ).toEqual({
@@ -72,14 +72,14 @@ describe('formikToTriggerUiMetadata', () => {
 
 describe('formikToCondition', () => {
   test('can return condition when searchType is query', () => {
-    const formikValues = _.cloneDeep(FORMIK_INITIAL_VALUES);
+    const formikValues = _.cloneDeep(FORMIK_INITIAL_TRIGGER_VALUES);
     expect(formikToCondition(formikValues, { search: { searchType: 'query' } })).toEqual({
       script: formikValues.script,
     });
   });
 
   test('can return condition when searchType is ad', () => {
-    const formikValues = _.cloneDeep(FORMIK_INITIAL_VALUES);
+    const formikValues = _.cloneDeep(FORMIK_INITIAL_TRIGGER_VALUES);
     expect(formikToCondition(formikValues, { search: { searchType: 'ad' } })).toEqual({
       script: {
         lang: 'painless',
@@ -90,19 +90,19 @@ describe('formikToCondition', () => {
   });
 
   test('can return condition when there is no monitorUiMetadata', () => {
-    const formikValues = _.cloneDeep(FORMIK_INITIAL_VALUES);
+    const formikValues = _.cloneDeep(FORMIK_INITIAL_TRIGGER_VALUES);
     expect(formikToCondition(formikValues)).toEqual({ script: formikValues.script });
   });
 
   test('can return condition for count aggregation', () => {
-    const formikValues = _.cloneDeep(FORMIK_INITIAL_VALUES);
+    const formikValues = _.cloneDeep(FORMIK_INITIAL_TRIGGER_VALUES);
     expect(
       formikToCondition(formikValues, { search: { searchType: 'graph', aggregationType: 'count' } })
     ).toEqual({ script: { lang: 'painless', source: `ctx.results[0].hits.total.value > 10000` } });
   });
 
   test('can return condition for other aggregations', () => {
-    const formikValues = _.cloneDeep(FORMIK_INITIAL_VALUES);
+    const formikValues = _.cloneDeep(FORMIK_INITIAL_TRIGGER_VALUES);
     expect(
       formikToCondition(formikValues, { search: { searchType: 'graph', aggregationType: 'max' } })
     ).toEqual({

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/triggerToFormik.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/triggerToFormik.js
@@ -14,7 +14,7 @@
  */
 
 import _ from 'lodash';
-import { FORMIK_INITIAL_VALUES, TRIGGER_TYPE } from './constants';
+import { FORMIK_INITIAL_TRIGGER_VALUES, TRIGGER_TYPE } from './constants';
 
 export function triggerToFormik(trigger, monitor) {
   const {
@@ -29,36 +29,36 @@ export function triggerToFormik(trigger, monitor) {
   const thresholdEnum = _.get(
     monitor,
     `ui_metadata.triggers[${name}].enum`,
-    FORMIK_INITIAL_VALUES.thresholdEnum
+    FORMIK_INITIAL_TRIGGER_VALUES.thresholdEnum
   );
   const thresholdValue = _.get(
     monitor,
     `ui_metadata.triggers[${name}].value`,
-    FORMIK_INITIAL_VALUES.thresholdValue
+    FORMIK_INITIAL_TRIGGER_VALUES.thresholdValue
   );
   const anomalyConfidenceThresholdValue = _.get(
     monitor,
     `ui_metadata.triggers[${name}].adTriggerMetadata.anomalyConfidence.value`,
-    FORMIK_INITIAL_VALUES.anomalyDetector.anomalyConfidenceThresholdValue
+    FORMIK_INITIAL_TRIGGER_VALUES.anomalyDetector.anomalyConfidenceThresholdValue
   );
   const anomalyConfidenceThresholdEnum = _.get(
     monitor,
     `ui_metadata.triggers[${name}].adTriggerMetadata.anomalyConfidence.enum`,
-    FORMIK_INITIAL_VALUES.anomalyDetector.anomalyConfidenceThresholdEnum
+    FORMIK_INITIAL_TRIGGER_VALUES.anomalyDetector.anomalyConfidenceThresholdEnum
   );
   const anomalyGradeThresholdValue = _.get(
     monitor,
     `ui_metadata.triggers[${name}].adTriggerMetadata.anomalyGrade.value`,
-    FORMIK_INITIAL_VALUES.anomalyDetector.anomalyGradeThresholdValue
+    FORMIK_INITIAL_TRIGGER_VALUES.anomalyDetector.anomalyGradeThresholdValue
   );
   const anomalyGradeThresholdEnum = _.get(
     monitor,
     `ui_metadata.triggers[${name}].adTriggerMetadata.anomalyGrade.enum`,
-    FORMIK_INITIAL_VALUES.anomalyDetector.anomalyGradeThresholdEnum
+    FORMIK_INITIAL_TRIGGER_VALUES.anomalyDetector.anomalyGradeThresholdEnum
   );
   const triggerType = _.get(monitor, `ui_metadata.triggers[${name}].adTriggerMetadata.triggerType`);
   return {
-    ..._.cloneDeep(FORMIK_INITIAL_VALUES),
+    ..._.cloneDeep(FORMIK_INITIAL_TRIGGER_VALUES),
     id,
     name,
     severity,

--- a/public/pages/CreateTrigger/containers/DefineAggregationTrigger/DefineAggregationTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineAggregationTrigger/DefineAggregationTrigger.js
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import { EuiAccordion, EuiButton, EuiSpacer } from '@elastic/eui';
+import 'brace/mode/plain_text';
+import { FormikFieldText, FormikSelect } from '../../../../components/FormControls';
+import { isInvalid, hasError } from '../../../../utils/validate';
+import ContentPanel from '../../../../components/ContentPanel/index';
+import { SEARCH_TYPE } from '../../../../utils/constants';
+import { TRIGGER_TYPE } from '../CreateTrigger/utils/constants';
+import AddTriggerButton from '../../components/AddTriggerButton';
+import TriggerEmptyPrompt from '../../components/TriggerEmptyPrompt';
+import AggregationTriggerGraph from '../../components/AggregationTriggerGraph';
+import AggregationTriggerQuery from '../../components/AggregationTriggerQuery';
+import { validateTriggerName } from '../DefineTrigger/utils/validation';
+import WhereExpression from '../../../CreateMonitor/components/MonitorExpressions/expressions/WhereExpression';
+
+const defaultRowProps = {
+  label: 'Trigger name',
+  helpText: `Trigger names must be unique. Names can only contain letters, numbers, and special characters.`,
+  style: { paddingLeft: '10px' },
+  isInvalid,
+  error: hasError,
+};
+const defaultInputProps = { isInvalid };
+
+const selectFieldProps = {
+  validate: () => {},
+};
+
+const selectRowProps = {
+  label: 'Severity level',
+  helpText: `Severity levels help you organize your triggers and actions. A trigger with a high severity level might page a specific individual, whereas a trigger with a low severity level might email a list.`,
+  style: { paddingLeft: '10px', marginTop: '0px' },
+  isInvalid,
+  error: hasError,
+};
+const severityOptions = [
+  { value: '1', text: '1' },
+  { value: '2', text: '2' },
+  { value: '3', text: '3' },
+  { value: '4', text: '4' },
+  { value: '5', text: '5' },
+];
+
+const triggerOptions = [{ value: TRIGGER_TYPE.ALERT_TRIGGER, text: 'Extraction query response' }];
+
+const selectInputProps = {
+  options: severityOptions,
+};
+
+const propTypes = {
+  context: PropTypes.object.isRequired,
+  executeResponse: PropTypes.object,
+  monitorValues: PropTypes.object.isRequired,
+  onRun: PropTypes.func.isRequired,
+  setFlyout: PropTypes.func.isRequired,
+  triggers: PropTypes.arrayOf(PropTypes.object).isRequired,
+  triggerValues: PropTypes.object.isRequired,
+  isDarkMode: PropTypes.bool.isRequired,
+};
+
+const renderWhereExpression = (
+  openedStates,
+  closeExpression,
+  openExpression,
+  onMadeChanges,
+  dataTypes
+) => {
+  return (
+    <WhereExpression
+      openedStates={openedStates}
+      closeExpression={closeExpression}
+      openExpression={openExpression}
+      onMadeChanges={onMadeChanges}
+      dataTypes={dataTypes}
+    />
+  );
+};
+
+const renderAggregationTriggerGraph = (index, monitor, monitorValues, response, triggerValues) => {
+  const andOrCondition = triggerValues.triggerConditions[index].andOrCondition;
+  const queryMetric = triggerValues.triggerConditions[index].queryMetric;
+  const thresholdEnum = triggerValues.triggerConditions[index].thresholdEnum;
+  const thresholdValue = triggerValues.triggerConditions[index].thresholdValue;
+
+  const aggregations = _.keys(
+    _.get(monitor, 'inputs[0].search.query.aggregations.composite_agg.aggregations', [])
+  );
+  const compositeAggregations = _.get(
+    monitor,
+    'inputs[0].search.query.aggregations.composite_agg.composite.sources',
+    []
+  ).flatMap((entry) => _.keys(entry));
+  const allAggregations = _.concat(aggregations, compositeAggregations);
+
+  return (
+    <AggregationTriggerGraph
+      index={index}
+      andOrCondition={andOrCondition}
+      monitorValues={monitorValues}
+      response={response}
+      queryMetric={queryMetric}
+      queryMetrics={allAggregations}
+      thresholdEnum={thresholdEnum}
+      thresholdValue={thresholdValue}
+    />
+  );
+};
+
+const renderAggregationTriggerQuery = (
+  index,
+  context,
+  error,
+  executeResponse,
+  onRun,
+  response,
+  setFlyout,
+  triggerValues,
+  isDarkMode
+) => {
+  return (
+    <AggregationTriggerQuery
+      index={index}
+      context={context}
+      error={error}
+      executeResponse={executeResponse}
+      onRun={onRun}
+      response={response}
+      setFlyout={setFlyout}
+      triggerValues={triggerValues}
+      isDarkMode={isDarkMode}
+    />
+  );
+};
+
+const DefineAggregationTrigger = ({
+  arrayHelpers,
+  context,
+  executeResponse,
+  monitor,
+  monitorValues,
+  onRun,
+  setFlyout,
+  triggers,
+  triggerValues,
+  isDarkMode,
+  openedStates,
+  closeExpression,
+  openExpression,
+  onMadeChanges,
+  dataTypes,
+}) => {
+  const isGraph = _.get(monitorValues, 'searchType') === SEARCH_TYPE.GRAPH;
+  const response = _.get(executeResponse, 'input_results.results[0]');
+  const error = _.get(executeResponse, 'error') || _.get(executeResponse, 'input_results.error');
+
+  const hasTriggerConditions = !_.isEmpty(triggerValues.triggerConditions);
+
+  let aggregationTriggerContent = hasTriggerConditions ? (
+    triggerValues.triggerConditions.map((trigCondition, index) => (
+      <EuiAccordion
+        key={`${index}`}
+        id={`${index}`}
+        initialIsOpen={hasTriggerConditions}
+        className={'trigger-condition-accordion'}
+        buttonContent={`Trigger condition ${index + 1}`}
+        extraAction={
+          <div style={{ paddingRight: '10px' }}>
+            <EuiButton
+              onClick={() => {
+                arrayHelpers.remove(index);
+              }}
+            >
+              Delete
+            </EuiButton>
+          </div>
+        }
+      >
+        {isGraph
+          ? renderAggregationTriggerGraph(index, monitor, monitorValues, response, triggerValues)
+          : renderAggregationTriggerQuery(
+              index,
+              context,
+              error,
+              executeResponse,
+              onRun,
+              response,
+              setFlyout,
+              triggerValues,
+              isDarkMode
+            )}
+      </EuiAccordion>
+    ))
+  ) : (
+    <TriggerEmptyPrompt arrayHelpers={arrayHelpers} />
+  );
+
+  return (
+    <ContentPanel title="Define trigger" titleSize="s" bodyStyles={{ padding: 'initial' }}>
+      <FormikFieldText
+        name="name"
+        fieldProps={{ validate: validateTriggerName(triggers, triggerValues) }}
+        formRow
+        rowProps={defaultRowProps}
+        inputProps={defaultInputProps}
+      />
+      <FormikSelect
+        name="severity"
+        formRow
+        fieldProps={selectFieldProps}
+        rowProps={selectRowProps}
+        inputProps={selectInputProps}
+      />
+      {aggregationTriggerContent}
+      <div style={{ paddingLeft: '10px' }}>
+        <AddTriggerButton arrayHelpers={arrayHelpers} />
+        <EuiSpacer />
+        {isGraph
+          ? renderWhereExpression(
+              openedStates,
+              closeExpression,
+              openExpression,
+              onMadeChanges,
+              dataTypes
+            )
+          : null}
+      </div>
+    </ContentPanel>
+  );
+};
+
+DefineAggregationTrigger.propTypes = propTypes;
+
+export default DefineAggregationTrigger;

--- a/public/pages/CreateTrigger/containers/DefineAggregationTrigger/index.js
+++ b/public/pages/CreateTrigger/containers/DefineAggregationTrigger/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import DefineAggregationTrigger from './DefineAggregationTrigger';
+
+export default DefineAggregationTrigger;

--- a/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
@@ -105,7 +105,9 @@ const renderTriggerContents = (
   const adValues = isTraditionalMonitor
     ? triggerValues.anomalyDetector
     : triggerValues.triggerConditions[index].anomalyDetector;
-  const adTriggerType = triggerValues.anomalyDetector.triggerType;
+  const adTriggerType = isTraditionalMonitor
+    ? triggerValues.anomalyDetector.triggerType
+    : triggerValues.triggerConditions[index].anomalyDetector.triggerType;
 
   let triggerContent = (
     <TriggerQuery
@@ -117,6 +119,7 @@ const renderTriggerContents = (
       setFlyout={setFlyout}
       triggerValues={triggerValues}
       isDarkMode={isDarkMode}
+      index={index}
     />
   );
   if (isAd && adTriggerType === TRIGGER_TYPE.AD) {

--- a/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
@@ -102,12 +102,8 @@ const renderTriggerContents = (
   const thresholdValue = isTraditionalMonitor
     ? triggerValues.thresholdValue
     : triggerValues.triggerConditions[index].thresholdValue;
-  const adValues = isTraditionalMonitor
-    ? triggerValues.anomalyDetector
-    : triggerValues.triggerConditions[index].anomalyDetector;
-  const adTriggerType = isTraditionalMonitor
-    ? triggerValues.anomalyDetector.triggerType
-    : triggerValues.triggerConditions[index].anomalyDetector.triggerType;
+  const adValues = triggerValues.anomalyDetector;
+  const adTriggerType = triggerValues.anomalyDetector.triggerType;
 
   let triggerContent = (
     <TriggerQuery

--- a/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
@@ -16,7 +16,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { EuiAccordion, EuiButton } from '@elastic/eui';
 import 'brace/mode/plain_text';
 import { FormikFieldText, FormikSelect } from '../../../../components/FormControls';
 import { isInvalid, hasError } from '../../../../utils/validate';
@@ -27,8 +26,6 @@ import { validateTriggerName } from './utils/validation';
 import { SEARCH_TYPE } from '../../../../utils/constants';
 import { AnomalyDetectorTrigger } from './AnomalyDetectorTrigger';
 import { TRIGGER_TYPE } from '../CreateTrigger/utils/constants';
-import AddTriggerButton from '../../components/AddTriggerButton';
-import TriggerEmptyPrompt from '../../components/TriggerEmptyPrompt';
 
 const defaultRowProps = {
   label: 'Trigger name',
@@ -78,9 +75,7 @@ const propTypes = {
   isDarkMode: PropTypes.bool.isRequired,
 };
 
-const renderTriggerContents = (
-  arrayHelpers,
-  isTraditionalMonitor,
+const DefineTrigger = ({
   context,
   executeResponse,
   monitorValues,
@@ -89,22 +84,15 @@ const renderTriggerContents = (
   triggers,
   triggerValues,
   isDarkMode,
-  index
-) => {
+}) => {
   const isGraph = _.get(monitorValues, 'searchType') === SEARCH_TYPE.GRAPH;
   const isAd = _.get(monitorValues, 'searchType') === SEARCH_TYPE.AD;
   const detectorId = _.get(monitorValues, 'detectorId');
   const response = _.get(executeResponse, 'input_results.results[0]');
   const error = _.get(executeResponse, 'error') || _.get(executeResponse, 'input_results.error');
-  const thresholdEnum = isTraditionalMonitor
-    ? triggerValues.thresholdEnum
-    : triggerValues.triggerConditions[index].thresholdEnum;
-  const thresholdValue = isTraditionalMonitor
-    ? triggerValues.thresholdValue
-    : triggerValues.triggerConditions[index].thresholdValue;
-  const adValues = triggerValues.anomalyDetector;
+  const thresholdEnum = triggerValues.thresholdEnum;
+  const thresholdValue = triggerValues.thresholdValue;
   const adTriggerType = triggerValues.anomalyDetector.triggerType;
-
   let triggerContent = (
     <TriggerQuery
       context={context}
@@ -115,16 +103,16 @@ const renderTriggerContents = (
       setFlyout={setFlyout}
       triggerValues={triggerValues}
       isDarkMode={isDarkMode}
-      index={index}
     />
   );
   if (isAd && adTriggerType === TRIGGER_TYPE.AD) {
-    triggerContent = <AnomalyDetectorTrigger detectorId={detectorId} adValues={adValues} />;
+    triggerContent = (
+      <AnomalyDetectorTrigger detectorId={detectorId} adValues={triggerValues.anomalyDetector} />
+    );
   }
   if (isGraph) {
     triggerContent = (
       <TriggerGraph
-        index={index}
         monitorValues={monitorValues}
         response={response}
         thresholdEnum={thresholdEnum}
@@ -132,104 +120,6 @@ const renderTriggerContents = (
       />
     );
   }
-
-  return triggerContent;
-};
-
-const renderTriggerConditions = (
-  arrayHelpers,
-  isTraditionalMonitor,
-  context,
-  executeResponse,
-  monitorValues,
-  onRun,
-  setFlyout,
-  triggers,
-  triggerValues,
-  isDarkMode
-) => {
-  const hasTriggerConditions = !_.isEmpty(triggerValues.triggerConditions);
-
-  return hasTriggerConditions ? (
-    triggerValues.triggerConditions.map((trigCondition, index) => (
-      <EuiAccordion
-        key={`${index}`}
-        id={`${index}`}
-        initialIsOpen={hasTriggerConditions}
-        className={'trigger-condition-accordion'}
-        buttonContent={`Trigger condition ${index + 1}`}
-        extraAction={
-          <div style={{ paddingRight: '10px' }}>
-            <EuiButton
-              onClick={() => {
-                arrayHelpers.remove(index);
-              }}
-            >
-              Delete
-            </EuiButton>
-          </div>
-        }
-      >
-        {renderTriggerContents(
-          arrayHelpers,
-          isTraditionalMonitor,
-          context,
-          executeResponse,
-          monitorValues,
-          onRun,
-          setFlyout,
-          triggers,
-          triggerValues,
-          isDarkMode,
-          index
-        )}
-      </EuiAccordion>
-    ))
-  ) : (
-    <TriggerEmptyPrompt arrayHelpers={arrayHelpers} />
-  );
-};
-
-const DefineTrigger = ({
-  arrayHelpers,
-  monitor,
-  context,
-  executeResponse,
-  monitorValues,
-  onRun,
-  setFlyout,
-  triggers,
-  triggerValues,
-  isDarkMode,
-}) => {
-  const isAd = _.get(monitorValues, 'searchType') === SEARCH_TYPE.AD;
-  const isTraditionalMonitor = _.get(monitor, 'monitor_type') === 'traditional_monitor';
-
-  const triggerContents = isTraditionalMonitor
-    ? renderTriggerContents(
-        arrayHelpers,
-        isTraditionalMonitor,
-        context,
-        executeResponse,
-        monitorValues,
-        onRun,
-        setFlyout,
-        triggers,
-        triggerValues,
-        isDarkMode
-      )
-    : renderTriggerConditions(
-        arrayHelpers,
-        isTraditionalMonitor,
-        context,
-        executeResponse,
-        monitorValues,
-        onRun,
-        setFlyout,
-        triggers,
-        triggerValues,
-        isDarkMode
-      );
 
   return (
     <ContentPanel title="Define trigger" titleSize="s" bodyStyles={{ padding: 'initial' }}>
@@ -259,12 +149,7 @@ const DefineTrigger = ({
           inputProps={{ options: triggerOptions }}
         />
       ) : null}
-      {triggerContents}
-      {!isTraditionalMonitor ? (
-        <div style={{ paddingLeft: '10px' }}>
-          <AddTriggerButton arrayHelpers={arrayHelpers} />
-        </div>
-      ) : null}
+      {triggerContent}
     </ContentPanel>
   );
 };

--- a/public/pages/MonitorDetails/containers/Triggers/Triggers.js
+++ b/public/pages/MonitorDetails/containers/Triggers/Triggers.js
@@ -56,7 +56,7 @@ export default class Triggers extends Component {
       (map, item) => ({ ...map, [item.name]: true }),
       {}
     );
-    const shouldKeepTrigger = trigger => !triggersToDelete[trigger.name];
+    const shouldKeepTrigger = (trigger) => !triggersToDelete[trigger.name];
     const updatedTriggers = monitor.triggers.filter(shouldKeepTrigger);
     updateMonitor({ triggers: updatedTriggers });
   }
@@ -76,23 +76,24 @@ export default class Triggers extends Component {
   render() {
     const { direction, field, selectedItems, tableKey } = this.state;
     const { monitor, onCreateTrigger } = this.props;
+    const isAggregationMonitor = monitor.monitor_type === 'aggregation_monitor';
 
     const columns = [
       {
-        field: 'name',
+        field: isAggregationMonitor ? 'aggregation_trigger.name' : 'name',
         name: 'Name',
         sortable: true,
         truncateText: true,
       },
       {
-        field: 'actions',
+        field: isAggregationMonitor ? 'aggregation_trigger.actions' : 'actions',
         name: 'Number of actions',
         sortable: true,
         truncateText: false,
-        render: actions => actions.length,
+        render: (actions) => actions.length,
       },
       {
-        field: 'severity',
+        field: isAggregationMonitor ? 'aggregation_trigger.severity' : 'severity',
         name: 'Severity',
         sortable: true,
         truncateText: false,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Refactored `CreateTrigger` to use a `FieldArray` to support multiple trigger conditions.
2. Refactored `DefineTrigger` to render different UX for `traditional` vs. `aggregation` monitors.
3. Implemented `AddTriggerButton` to support quickly adding new trigger conditions.
4. Implemented `TriggerEmptyPrompt` to inform users of aggregation monitors to create trigger conditions.
5. Renamed `FORMIK_INITIAL_VALUES` constant to `FORMIK_INITIAL_TRIGGER_VALUES` for clarity.
6. Implemented `FORMIK_INITIAL_TRIGGER_CONDITION_VALUES` constant to support adding new trigger conditions.

**Known issues**
1. This implementation does not support creation of triggers with multiple trigger conditions; additional logic will need to be implemented first. These changes just introduce the framework for rendering multiple conditions.
2. UX design is not final. This implementation could use some polishing, but we may want to wait until we have a final design in mind before investing time in that.

**No trigger conditions**
![doc level UX no trigger conditions](https://user-images.githubusercontent.com/79280347/119893609-6fad7800-bef0-11eb-960d-2b04cc12f701.png)

**Multiple trigger conditions**
![doc level UX multiple trigger conditions](https://user-images.githubusercontent.com/79280347/119893665-805dee00-bef0-11eb-9e48-26e1786cbf07.png)

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.