### PR TITLE
Commented out a line of code that was preventing trigger WHERE expression popovers from closing, and refactored formikToTrigger to leave the composite_agg_filter undefined if the user doesn't make any selections instead of returning an empty object. 

### DIFF
--- a/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger.js
@@ -255,7 +255,11 @@ export default class CreateTrigger extends Component {
     const { madeChanges, openedStates } = this.state;
     if (madeChanges && openedStates[expression]) {
       // if made changes and close expression that was currently open => run query
-      this.props.onRunQuery();
+
+      // TODO: Re-enable once we have implementation to support
+      //  rendering visual graphs for aggregation triggers.
+      // this.props.onRunQuery();
+
       this.setState({ madeChanges: false });
     }
     this.setState({ openedStates: { ...openedStates, [expression]: false } });

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
@@ -1,16 +1,16 @@
 /*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
  */
 
 import { OPERATORS_MAP } from '../../../../CreateMonitor/components/MonitorExpressions/expressions/utils/constants';

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
@@ -205,8 +205,8 @@ export function getCompositeAggFilter({ where }) {
     composite_agg_filter[where.fieldName[0].label] = {
       [where.operator]: where.fieldValue,
     };
+    return composite_agg_filter;
   }
-  return composite_agg_filter;
 }
 
 export function getRelationalOperator(thresholdEnum) {

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/triggerToFormik.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/triggerToFormik.js
@@ -220,6 +220,8 @@ export function convertToTriggerCondition(conditionArray, condition) {
 }
 
 export function getWhereExpression(composite_agg_filter) {
+  if (composite_agg_filter === undefined) return;
+
   const fields = _.keys(composite_agg_filter);
   const field = fields[0];
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Commented out `line 258` of `CreateTrigger.js` as it was preventing the WHERE expression popovers from closing on the trigger creation page. Will re-enable when support for rendering visual graphs is implemented for aggregation triggers.
2. Refactored formikToTrigger to leave the `composite_agg_filter` `undefined` if the user doesn't make any selections instead of returning an empty object. 

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.